### PR TITLE
docs: refine comments and document functions across repo

### DIFF
--- a/src/backend/reply.ts
+++ b/src/backend/reply.ts
@@ -1,11 +1,14 @@
-// Reply sending API stub for vxMailAgent
-// Implements reply sending per Example.md, to be invoked from orchestration logic
 import { Reply } from '../shared/types';
 
-export async function sendReply(reply: Reply, provider: 'gmail' | 'outlook', account: any): Promise<{ success: boolean; error?: string }> {
-  // TODO: Implement provider-specific reply sending
-  // For now, log and return stub
+/**
+ * Sends an email reply through the chosen provider.
+ * Currently logs the request and returns a success placeholder.
+ */
+export async function sendReply(
+  reply: Reply,
+  provider: 'gmail' | 'outlook',
+  account: any,
+): Promise<{ success: boolean; error?: string }> {
   console.log('[REPLY] sendReply called', { reply, provider, account });
-  // Simulate success
   return { success: true };
 }

--- a/src/backend/repository/core.ts
+++ b/src/backend/repository/core.ts
@@ -1,7 +1,9 @@
-// Generic repository interfaces
+/**
+ * Basic repository interface for entities persisted on disk.
+ */
 export interface Repository<T> {
-  // Always read fresh from disk
+  /** Retrieve all records from storage. */
   getAll(): T[];
-  // Persist entire collection
+  /** Replace the entire collection in storage. */
   setAll(next: T[]): void;
 }

--- a/src/backend/routes/health.ts
+++ b/src/backend/routes/health.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 
+/** Register a simple health check endpoint. */
 export default function registerHealthRoutes(app: express.Express) {
   app.get('/api/health', (_req, res) => {
     console.log(`[${new Date().toISOString()}] Health check request received`);

--- a/src/backend/services/cleanup.ts
+++ b/src/backend/services/cleanup.ts
@@ -1,7 +1,6 @@
 import { CleanupStats } from '../../shared/types';
 
-// Centralized, ids-only cleanup service operating strictly via repository accessors.
-
+/** Accessors for repositories used by the cleanup service. */
 export interface RepositoryHub<TConv = any, TOrch = any, TProv = any, TTrace = any, TFetch = any> {
   getConversations: () => TConv[];
   setConversations: (next: TConv[]) => void;
@@ -15,6 +14,7 @@ export interface RepositoryHub<TConv = any, TOrch = any, TProv = any, TTrace = a
   setFetcherLog: (next: TFetch[]) => void;
 }
 
+/** Operations exposed by the cleanup service. */
 export interface CleanupService {
   removeConversationsByIds: (ids: string[]) => { deleted: number };
   removeOrchestrationByIds: (ids: string[]) => { deleted: number };
@@ -26,6 +26,9 @@ export interface CleanupService {
   purge: (type: 'fetcher' | 'orchestration' | 'conversations' | 'providerEvents' | 'traces') => { deleted: number; message: string };
 }
 
+/**
+ * Builds an ids-only cleanup service that operates via the provided repository accessors.
+ */
 export function createCleanupService(hub: RepositoryHub): CleanupService {
   const isoNow = () => new Date().toISOString();
 

--- a/src/backend/services/conversations.ts
+++ b/src/backend/services/conversations.ts
@@ -1,6 +1,10 @@
- import { ConversationThread } from '../../shared/types';
+import { ConversationThread } from '../../shared/types';
 
- export function isDirectorFinalized(conversations: ConversationThread[], dirId: string): boolean {
+/** Returns true if the specified director conversation has been finalized. */
+export function isDirectorFinalized(
+  conversations: ConversationThread[],
+  dirId: string
+): boolean {
   const d = conversations.find(c => c.id === dirId && c.kind === 'director');
   return !!d && (d.finalized === true || (d as any).status === 'finalized');
- }
+}

--- a/src/backend/utils/graph.ts
+++ b/src/backend/utils/graph.ts
@@ -1,3 +1,10 @@
+/**
+ * Performs an HTTP request to the Microsoft Graph API and returns the parsed JSON body.
+ * @param pathWithQuery Graph path including query string.
+ * @param accessToken OAuth access token for authorization.
+ * @param method HTTP method to use.
+ * @param body Optional JSON payload string.
+ */
 export async function graphRequest<T = any>(
   pathWithQuery: string,
   accessToken: string,

--- a/src/backend/utils/id.ts
+++ b/src/backend/utils/id.ts
@@ -1,4 +1,8 @@
+/**
+ * Generates a short random identifier based on the current time and randomness.
+ */
 export const newId = (): string =>
   Date.now().toString(36) + Math.random().toString(36).slice(2);
 
+/** Returns the current time in ISO 8601 format. */
 export const nowIso = (): string => new Date().toISOString();

--- a/src/backend/utils/paths.ts
+++ b/src/backend/utils/paths.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import { DATA_DIR } from '../persistence';
 
+/** Resolves a file path within the persistent data directory. */
 export const dataPath = (name: string) => path.join(DATA_DIR, name);
 
 export const ACCOUNTS_FILE = dataPath('accounts.json');

--- a/src/backend/utils/tools.ts
+++ b/src/backend/utils/tools.ts
@@ -3,14 +3,14 @@ import { ConversationRole, RoleCapabilities, ToolDescriptor } from '../../shared
 
 export type OptionalTool = typeof OPTIONAL_TOOL_NAMES[number];
 
-// Build optional tool specs based on an allowlist set
+/** Build optional tool specs from the registry using an allowlist. */
 export function buildOptionalToolSpecs(allowed: Set<string>): any[] {
   return TOOL_REGISTRY
     .filter(t => t.category === 'optional' && allowed.has(t.name))
     .map(t => ({ type: 'function', function: { name: t.name, description: t.description, parameters: t.parameters } }));
 }
 
-// Build core, read-only tool specs. Accept a set of names to include; if empty, include all core tools.
+/** Build core tool specs, optionally limited to a set of names. */
 export function buildCoreToolSpecs(include?: Set<string>): any[] {
   const want = include && include.size ? include : new Set(TOOL_REGISTRY.filter(t => t.category === 'mandatory').map(t => t.name));
   return TOOL_REGISTRY
@@ -18,26 +18,22 @@ export function buildCoreToolSpecs(include?: Set<string>): any[] {
     .map(t => ({ type: 'function', function: { name: t.name, description: t.description, parameters: t.parameters } }));
 }
 
-// Removed legacy buildAgentToolSpecs; engine + flags-based descriptors are canonical.
-
-// --- New flags-based helpers (preferred path) ---
-
 function toOpenAiToolSpec(desc: ToolDescriptor): any {
   return { type: 'function', function: { name: desc.name, description: desc.description, parameters: desc.inputSchema } };
 }
 
+/**
+ * Select tool specs for the given role based on descriptor flags.
+ * Role capabilities are currently unused but reserved for future expansion.
+ */
 export function buildToolSpecsByFlags(role: ConversationRole, roleCaps: RoleCapabilities): any[] {
-  // reference roleCaps to avoid lint for now; engine will use this to add dynamic tools (e.g., CallAgent)
   const canSpawn = roleCaps?.canSpawnAgents === true;
   void canSpawn;
   const enabled = TOOL_DESCRIPTORS.filter((d) => {
     const f = d.flags || {};
-    // mandatory always included for applicable roles; directorOnly hides from agents
     if (f.mandatory) return role === 'director' || !f.directorOnly;
-    // defaultEnabled gated by role visibility
     if (f.defaultEnabled) return role === 'director' || !f.directorOnly;
     return false;
   });
-  // Engine will also decide whether to add orchestration-only dynamic tools (e.g., CallAgent) based on roleCaps.canSpawnAgents
   return enabled.map(toOpenAiToolSpec);
 }

--- a/src/backend/validation.ts
+++ b/src/backend/validation.ts
@@ -1,6 +1,15 @@
-// Minimal JSON Schema validator (subset)
-// Shared utility for backend schema validation.
-export function validateAgainstSchema(schema: any, params: any, path: string = ''): string[] {
+/**
+ * Validates parameters against a minimal subset of JSON Schema.
+ * @param schema Schema definition to validate against.
+ * @param params Data to validate.
+ * @param path Path used to prefix error messages.
+ * @returns Array of validation error messages.
+ */
+export function validateAgainstSchema(
+  schema: any,
+  params: any,
+  path: string = '',
+): string[] {
   const errors: string[] = [];
   if (!schema || typeof schema !== 'object') return errors;
   const type = schema.type;

--- a/src/frontend/src/utils/api.ts
+++ b/src/frontend/src/utils/api.ts
@@ -1,5 +1,7 @@
-// Simple frontend API client for diagnostics endpoints
-// Provides typed helpers and consistent error handling
+/**
+ * Frontend API client for diagnostics and cleanup endpoints.
+ * Provides typed helpers and consistent error handling.
+ */
 
 export type SortDir = 'asc' | 'desc';
 
@@ -19,6 +21,7 @@ export interface OrchestrationListResponse<T = any> {
   items: T[];
 }
 
+/** Fetch orchestration diagnostics. */
 export async function getOrchestrationDiagnostics(params: OrchestrationListParams = {}): Promise<OrchestrationListResponse> {
   const qs = new URLSearchParams();
   Object.entries(params).forEach(([k, v]) => {
@@ -30,11 +33,13 @@ export async function getOrchestrationDiagnostics(params: OrchestrationListParam
   return res.json();
 }
 
+/** Delete a single orchestration diagnostic entry. */
 export async function deleteOrchestrationDiagnosticOne(id: string): Promise<void> {
   const res = await fetch(`/api/orchestration/diagnostics/${encodeURIComponent(id)}`, { method: 'DELETE' });
   if (!res.ok) throw new Error(`Failed to delete orchestration diagnostic: ${res.status}`);
 }
 
+/** Delete multiple orchestration diagnostics. */
 export async function deleteOrchestrationDiagnosticsBulk(ids: string[]): Promise<void> {
   const res = await fetch('/api/orchestration/diagnostics', {
     method: 'DELETE',
@@ -44,7 +49,6 @@ export async function deleteOrchestrationDiagnosticsBulk(ids: string[]): Promise
   if (!res.ok) throw new Error(`Failed bulk delete orchestration diagnostics: ${res.status}`);
 }
 
-// Traces diagnostics
 export interface TracesListParams {
   limit?: number;
   offset?: number;
@@ -66,6 +70,7 @@ export interface TracesListResponse {
   items: TraceSummaryItem[];
 }
 
+/** Fetch trace summaries. */
 export async function getDiagnosticsTraces(params: TracesListParams = {}): Promise<TracesListResponse> {
   const qs = new URLSearchParams();
   if (typeof params.limit === 'number') qs.set('limit', String(params.limit));
@@ -76,19 +81,20 @@ export async function getDiagnosticsTraces(params: TracesListParams = {}): Promi
   return res.json();
 }
 
+/** Fetch details for a single trace. */
 export async function getDiagnosticsTrace(id: string): Promise<any> {
   const res = await fetch(`/api/diagnostics/trace/${encodeURIComponent(id)}`);
   if (!res.ok) throw new Error(`Failed trace detail: ${res.status}`);
   return res.json();
 }
 
+/** Retrieve runtime diagnostics information. */
 export async function getDiagnosticsRuntime(): Promise<any> {
   const res = await fetch('/api/diagnostics/runtime');
   if (!res.ok) throw new Error(`Failed runtime diagnostics: ${res.status}`);
   return res.json();
 }
 
-// Cleanup API
 export interface CleanupStats {
   fetcherLogs: number;
   orchestrationLogs: number;
@@ -98,49 +104,55 @@ export interface CleanupStats {
   total: number;
 }
 
+/** Retrieve cleanup statistics. */
 export async function getCleanupStats(): Promise<CleanupStats> {
   const res = await fetch('/api/cleanup/stats');
   if (!res.ok) throw new Error(`Failed to get cleanup stats: ${res.status}`);
   return res.json();
 }
 
+/** Remove all diagnostics and related data. */
 export async function cleanupAll(): Promise<{ success: boolean; deleted: CleanupStats; message: string }> {
   const res = await fetch('/api/cleanup/all', { method: 'DELETE' });
   if (!res.ok) throw new Error(`Failed to cleanup all: ${res.status}`);
   return res.json();
 }
 
+/** Delete fetcher log entries. */
 export async function cleanupFetcherLogs(): Promise<{ success: boolean; deleted: number; message: string }> {
   const res = await fetch('/api/cleanup/fetcher-logs', { method: 'DELETE' });
   if (!res.ok) throw new Error(`Failed to cleanup fetcher logs: ${res.status}`);
   return res.json();
 }
 
+/** Delete orchestration log entries. */
 export async function cleanupOrchestrationLogs(): Promise<{ success: boolean; deleted: number; message: string }> {
   const res = await fetch('/api/cleanup/orchestration-logs', { method: 'DELETE' });
   if (!res.ok) throw new Error(`Failed to cleanup orchestration logs: ${res.status}`);
   return res.json();
 }
 
+/** Delete stored conversations. */
 export async function cleanupConversations(): Promise<{ success: boolean; deleted: number; message: string }> {
   const res = await fetch('/api/cleanup/conversations', { method: 'DELETE' });
   if (!res.ok) throw new Error(`Failed to cleanup conversations: ${res.status}`);
   return res.json();
 }
 
+/** Delete provider event logs. */
 export async function cleanupProviderEvents(): Promise<{ success: boolean; deleted: number; message: string }> {
   const res = await fetch('/api/cleanup/provider-events', { method: 'DELETE' });
   if (!res.ok) throw new Error(`Failed to cleanup provider events: ${res.status}`);
   return res.json();
 }
 
+/** Delete trace records. */
 export async function cleanupTraces(): Promise<{ success: boolean; deleted: number; message: string }> {
   const res = await fetch('/api/cleanup/traces', { method: 'DELETE' });
   if (!res.ok) throw new Error(`Failed to cleanup traces: ${res.status}`);
   return res.json();
 }
 
-// Unified diagnostics
 export interface DiagnosticNode {
   id: string;
   type: 'fetchCycle' | 'account' | 'email' | 'director' | 'agent' | 'conversation' | 'providerEvent';
@@ -168,25 +180,28 @@ export interface UnifiedDiagnosticsResponse {
   };
 }
 
+/** Fetch aggregated diagnostics tree. */
 export async function getUnifiedDiagnostics(): Promise<UnifiedDiagnosticsResponse> {
   const res = await fetch('/api/diagnostics/unified');
   if (!res.ok) throw new Error(`Failed unified diagnostics: ${res.status}`);
   return res.json();
 }
 
+/** Fetch a node from the diagnostics tree. */
 export async function getUnifiedDiagnosticsNode(nodeId: string): Promise<any> {
   const res = await fetch(`/api/diagnostics/unified/${encodeURIComponent(nodeId)}`);
   if (!res.ok) throw new Error(`Failed to get diagnostic node: ${res.status}`);
   return res.json();
 }
 
-// Delete diagnostics traces
+/** Delete a single diagnostics trace. */
 export async function deleteDiagnosticsTrace(id: string): Promise<{ deleted: number }> {
   const res = await fetch(`/api/diagnostics/trace/${encodeURIComponent(id)}`, { method: 'DELETE' });
   if (!res.ok) throw new Error(`Failed to delete trace: ${res.status}`);
   return res.json();
 }
 
+/** Delete multiple diagnostics traces. */
 export async function deleteDiagnosticsTracesBulk(ids?: string[]): Promise<{ deleted: number }> {
   const init: RequestInit = { method: 'DELETE' };
   if (ids && ids.length) {

--- a/src/shared/tools.ts
+++ b/src/shared/tools.ts
@@ -1,5 +1,7 @@
-// Canonical tool registry shared by backend and frontend
-// Single source of truth for names, categories, descriptions, and parameter schemas.
+/**
+ * Canonical tool registry shared by backend and frontend.
+ * Provides a single source of truth for tool metadata and schemas.
+ */
 import { ToolDescriptor } from './types';
 
 export type ToolCategory = 'mandatory' | 'optional';
@@ -8,7 +10,6 @@ export interface ToolSpec {
   name: string;
   category: ToolCategory;
   description: string;
-  // JSON Schema for parameters
   parameters: any;
 }
 
@@ -39,8 +40,9 @@ export const TOOL_REGISTRY: ToolSpec[] = [
 
 export const CORE_TOOL_NAMES: string[] = TOOL_REGISTRY.filter(t => t.category === 'mandatory').map(t => t.name);
 export const OPTIONAL_TOOL_NAMES: string[] = TOOL_REGISTRY.filter(t => t.category === 'optional').map(t => t.name);
-
-// New: flags-based descriptors derived from TOOL_REGISTRY (KISS flags)
+/**
+ * Flags-based descriptors derived from the registry for selective tool exposure.
+ */
 export const TOOL_DESCRIPTORS: ToolDescriptor[] = TOOL_REGISTRY.map((t) => ({
   name: t.name,
   description: t.description,
@@ -48,7 +50,6 @@ export const TOOL_DESCRIPTORS: ToolDescriptor[] = TOOL_REGISTRY.map((t) => ({
   flags: {
     mandatory: t.category === 'mandatory',
     defaultEnabled: t.category === 'optional',
-    // No directorOnly tools in base registry; can be set ad-hoc where needed by wrapper logic
   },
 }));
 


### PR DESCRIPTION
## Summary
- clarify helper utilities with concise docstrings
- document orchestration and cleanup services while trimming noisy comments

## Testing
- `cd src/backend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68acc3dbd8e08329a555f71b38cc5890