### PR TITLE
docs: refine comments and add JSDoc

### DIFF
--- a/src/backend/auth.ts
+++ b/src/backend/auth.ts
@@ -1,10 +1,9 @@
-// OAuth logic for Gmail/Outlook
 import express from 'express';
 import { GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_REDIRECT_URI, OUTLOOK_CLIENT_ID, OUTLOOK_CLIENT_SECRET, OUTLOOK_REDIRECT_URI, JWT_SECRET } from './config';
 
+/** Router handling OAuth flows for Google and Outlook. */
 const router = express.Router();
 
-// Gmail OAuth2 endpoints (standardized via shared provider)
 import { buildGoogleAuthUrl, exchangeGoogleCode, getGoogleUserInfo } from './oauth/google';
 import { signJwt, verifyJwt } from './utils/jwt';
 import { computeExpiryISO } from './oauth/common';
@@ -32,7 +31,6 @@ router.get('/oauth2/google/callback', async (req: express.Request, res: express.
       return res.status(400).json({ error: 'Invalid or expired state' });
     }
     const tokens = await exchangeGoogleCode({ clientId: GOOGLE_ENV.CLIENT_ID, clientSecret: GOOGLE_ENV.CLIENT_SECRET, redirectUri: GOOGLE_ENV.REDIRECT_URI }, code);
-    // Fetch user info to get email via shared helper
     const me = await getGoogleUserInfo(tokens.accessToken);
     const email = me?.email || '';
     if (!email) return res.status(500).json({ error: 'Google profile missing email address' });
@@ -59,7 +57,6 @@ router.get('/oauth2/google/callback', async (req: express.Request, res: express.
   }
 });
 
-// Outlook OAuth2 endpoints
 import { getOutlookAuthUrl, getOutlookTokens, getOutlookUserInfo } from './oauth-outlook';
 
 const OUTLOOK_ENV = {
@@ -89,7 +86,6 @@ router.get('/oauth2/outlook/callback', async (req: express.Request, res: express
       return res.status(400).json({ error: 'Invalid or expired state' });
     }
     const tokenResponse = await getOutlookTokens(OUTLOOK_ENV.CLIENT_ID, OUTLOOK_ENV.CLIENT_SECRET, OUTLOOK_ENV.REDIRECT_URI, code);
-    // Try to extract email from id_token if present
     let email = '';
     if (tokenResponse?.id_token) {
       try {

--- a/src/backend/repository/fileRepositories.ts
+++ b/src/backend/repository/fileRepositories.ts
@@ -8,6 +8,7 @@ import {
 import { ProviderEvent, Trace } from '../../shared/types';
 import { TRACE_MAX_TRACES, TRACE_TTL_DAYS, PROVIDER_MAX_EVENTS, PROVIDER_TTL_DAYS } from '../config';
 
+/** Repository backed by an encrypted JSON file. */
 export class FileJsonRepository<T> implements Repository<T> {
   constructor(private filePath: string) {}
   getAll(): T[] {
@@ -27,10 +28,12 @@ export class FileJsonRepository<T> implements Repository<T> {
   }
 }
 
+/** Repository interface for provider events. */
 export interface ProviderEventsRepository extends Repository<ProviderEvent> {
   append(ev: ProviderEvent): void;
 }
 
+/** Provider events repository persisted to disk. */
 export class FileProviderEventsRepository implements ProviderEventsRepository {
   constructor(private filePath: string = PROVIDER_EVENTS_FILE) {}
   private prune(list: ProviderEvent[]): ProviderEvent[] {
@@ -69,11 +72,13 @@ export class FileProviderEventsRepository implements ProviderEventsRepository {
   }
 }
 
+/** Repository interface for traces. */
 export interface TracesRepository extends Repository<Trace> {
   append(t: Trace): void;
   update(id: string, updater: (t: Trace) => Trace | void): void;
 }
 
+/** Trace repository persisted to disk. */
 export class FileTracesRepository implements TracesRepository {
   constructor(private filePath: string = TRACES_FILE) {}
   private prune(list: Trace[]): Trace[] {
@@ -122,6 +127,7 @@ export class FileTracesRepository implements TracesRepository {
   }
 }
 
+/** Create a simple JSON file repository instance. */
 export function createJsonRepository<T>(filePath: string): Repository<T> {
   return new FileJsonRepository<T>(filePath);
 }

--- a/src/backend/routes/accounts.ts
+++ b/src/backend/routes/accounts.ts
@@ -5,9 +5,8 @@ import { ACCOUNTS_FILE } from '../utils/paths';
 import { GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_REDIRECT_URI, OUTLOOK_CLIENT_ID, OUTLOOK_CLIENT_SECRET, OUTLOOK_REDIRECT_URI, JWT_SECRET } from '../config';
 import { signJwt } from '../utils/jwt';
 
-
+/** Register routes for managing accounts and tokens. */
 export default function registerAccountsRoutes(app: express.Express) {
-  // GET /api/accounts
   app.get('/api/accounts', (_req, res) => {
     try {
       if (!require('fs').existsSync(ACCOUNTS_FILE)) {
@@ -22,8 +21,6 @@ export default function registerAccountsRoutes(app: express.Express) {
       res.status(500).json({ error: 'Failed to load accounts' });
     }
   });
-
-  // GET /api/accounts/:id/outlook-test
   app.get('/api/accounts/:id/outlook-test', async (req: express.Request, res: express.Response) => {
     const id = req.params.id;
     console.log(`[${new Date().toISOString()}] GET /api/accounts/${id}/outlook-test invoked`);
@@ -48,7 +45,6 @@ export default function registerAccountsRoutes(app: express.Express) {
         OUTLOOK_CLIENT_SECRET!
       );
       if (result.error) {
-        // Special-case: missing refresh token -> provide re-auth URL instead of hard error
         if (String(result.error).toLowerCase().includes('missing refresh token')) {
           try {
             const { getOutlookAuthUrl } = require('../oauth-outlook');
@@ -78,7 +74,6 @@ export default function registerAccountsRoutes(app: express.Express) {
         console.log(`[${new Date().toISOString()}] [OAUTH2] Refreshed + persisted during outlook-test for ${id}`);
       }
 
-      // Call Microsoft Graph: me and one message sample
       const doGet = (path: string) => new Promise<any>((resolve, reject) => {
         const https = require('https');
         const req = https.request({
@@ -115,8 +110,6 @@ export default function registerAccountsRoutes(app: express.Express) {
       res.status(500).json({ error: (e as any)?.message || String(e) });
     }
   });
-
-  // POST /api/accounts
   app.post('/api/accounts', (req, res) => {
     try {
       const newAccount: Account = req.body;
@@ -140,8 +133,6 @@ export default function registerAccountsRoutes(app: express.Express) {
       res.status(500).json({ error: 'Failed to save account' });
     }
   });
-
-  // PUT /api/accounts/:id
   app.put('/api/accounts/:id', (req: express.Request, res: express.Response) => {
     try {
       const id = req.params.id;
@@ -162,8 +153,6 @@ export default function registerAccountsRoutes(app: express.Express) {
       res.status(500).json({ error: 'Failed to update account' });
     }
   });
-
-  // DELETE /api/accounts/:id
   app.delete('/api/accounts/:id', async (req: express.Request, res: express.Response) => {
     console.log(`[DEBUG] DELETE /api/accounts/${req.params.id} invoked`);
     try {
@@ -225,8 +214,6 @@ export default function registerAccountsRoutes(app: express.Express) {
       res.status(500).json({ error: e instanceof Error ? e.message : String(e), details: e, revokeStatus, revokeError });
     }
   });
-
-  // POST /api/accounts/:id/refresh (Gmail)
   app.post('/api/accounts/:id/refresh', async (req: express.Request, res: express.Response) => {
     const id = req.params.id;
     console.log(`[${new Date().toISOString()}] POST /api/accounts/${id}/refresh invoked`);
@@ -265,7 +252,6 @@ export default function registerAccountsRoutes(app: express.Express) {
               error: errTxt,
             })
           );
-          // For missing/invalid refresh token, provide a re-auth URL like gmail-test does
           if (missing || invalidGrant) {
             try {
               const { buildGoogleAuthUrl } = require('../oauth/google');
@@ -281,10 +267,8 @@ export default function registerAccountsRoutes(app: express.Express) {
               return res.status(500).json({ ok: false, error: errTxt });
             }
           }
-          // Other errors: surface failure
           return res.status(500).json({ ok: false, error: errTxt });
         }
-        // Success path: persist updated tokens when provided
         if (result.updated) {
           account.tokens.accessToken = result.accessToken;
           account.tokens.expiry = result.expiry;
@@ -305,7 +289,6 @@ export default function registerAccountsRoutes(app: express.Express) {
           OUTLOOK_CLIENT_SECRET!
         );
         if (result.error) {
-          // Special-case: missing refresh token -> provide re-auth URL to complete
           if (String(result.error).toLowerCase().includes('missing refresh token')) {
             try {
               const { getOutlookAuthUrl } = require('../oauth-outlook');
@@ -342,8 +325,6 @@ export default function registerAccountsRoutes(app: express.Express) {
       res.status(500).json({ error: 'Refresh failed' });
     }
   });
-
-  // GET /api/accounts/:id/gmail-test
   app.get('/api/accounts/:id/gmail-test', async (req: express.Request, res: express.Response) => {
     const id = req.params.id;
     console.log(`[${new Date().toISOString()}] GET /api/accounts/${id}/gmail-test invoked`);
@@ -387,7 +368,6 @@ export default function registerAccountsRoutes(app: express.Express) {
             error: errTxt,
           })
         );
-        // Special-case: missing refresh token or invalid_grant -> provide re-auth URL
         if (missing || invalidGrant) {
           try {
             const { buildGoogleAuthUrl } = require('../oauth/google');

--- a/src/backend/routes/cleanup.ts
+++ b/src/backend/routes/cleanup.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import { FetcherLogEntry, CleanupStats } from '../../shared/types';
 import { createCleanupService, RepositoryHub } from '../services/cleanup';
 
+/** Dependencies for cleanup routes. */
 export interface CleanupRoutesDeps {
   getFetcherLog: () => FetcherLogEntry[];
   setFetcherLog: (next: FetcherLogEntry[]) => void;
@@ -17,6 +18,7 @@ export interface CleanupRoutesDeps {
   setTraces: (next: any[]) => void;
 }
 
+/** Register routes for diagnostics cleanup operations. */
 export default function registerCleanupRoutes(app: express.Express, deps: CleanupRoutesDeps) {
   const router = express.Router();
   const hub: RepositoryHub = {
@@ -34,8 +36,6 @@ export default function registerCleanupRoutes(app: express.Express, deps: Cleanu
     setTraces: (next: any[]) => deps.setTraces(next),
   };
   const svc = createCleanupService(hub);
-
-  // Get cleanup statistics (counts of each log type)
   router.get('/cleanup/stats', (_req, res) => {
     try {
       const stats: CleanupStats = svc.getStats();
@@ -44,8 +44,6 @@ export default function registerCleanupRoutes(app: express.Express, deps: Cleanu
       res.status(500).json({ error: 'Failed to get cleanup stats' });
     }
   });
-
-  // Purge all logs and data
   router.delete('/cleanup/all', (_req, res) => {
     try {
       const { deleted, message } = svc.purgeAll();
@@ -54,8 +52,6 @@ export default function registerCleanupRoutes(app: express.Express, deps: Cleanu
       res.status(500).json({ error: 'Failed to purge all logs' });
     }
   });
-
-  // Purge specific log types
   router.delete('/cleanup/fetcher-logs', (_req, res) => {
     try {
       const result = svc.purge('fetcher');
@@ -64,7 +60,6 @@ export default function registerCleanupRoutes(app: express.Express, deps: Cleanu
       res.status(500).json({ error: 'Failed to delete fetcher logs' });
     }
   });
-
   router.delete('/cleanup/orchestration-logs', (_req, res) => {
     try {
       const result = svc.purge('orchestration');
@@ -73,7 +68,6 @@ export default function registerCleanupRoutes(app: express.Express, deps: Cleanu
       res.status(500).json({ error: 'Failed to delete orchestration logs' });
     }
   });
-
   router.delete('/cleanup/conversations', (_req, res) => {
     try {
       const result = svc.purge('conversations');
@@ -82,7 +76,6 @@ export default function registerCleanupRoutes(app: express.Express, deps: Cleanu
       res.status(500).json({ error: 'Failed to delete conversations' });
     }
   });
-
   router.delete('/cleanup/workspace-items', (_req, res) => {
     try {
       const result = svc.purge('workspaceItems');
@@ -91,7 +84,6 @@ export default function registerCleanupRoutes(app: express.Express, deps: Cleanu
       res.status(500).json({ error: 'Failed to delete workspace items' });
     }
   });
-
   router.delete('/cleanup/provider-events', (_req, res) => {
     try {
       const result = svc.purge('providerEvents');
@@ -100,7 +92,6 @@ export default function registerCleanupRoutes(app: express.Express, deps: Cleanu
       res.status(500).json({ error: 'Failed to delete provider events' });
     }
   });
-
   router.delete('/cleanup/traces', (_req, res) => {
     try {
       const result = svc.purge('traces');

--- a/src/backend/routes/diagnostics.ts
+++ b/src/backend/routes/diagnostics.ts
@@ -2,13 +2,14 @@ import express from 'express';
 import { DATA_DIR } from '../utils/paths';
 import { VX_MAILAGENT_KEY } from '../config';
 
+/** Dependencies for diagnostics routes. */
 export interface DiagnosticsRoutesDeps {
   getOrchestrationLog: () => any[];
   getConversations: () => any[];
 }
 
+/** Register runtime diagnostics routes. */
 export default function registerDiagnosticsRoutes(app: express.Express, deps: DiagnosticsRoutesDeps) {
-  // Runtime diagnostics (display-only): encryption mode, counts, environment
   app.get('/api/diagnostics/runtime', (_req, res) => {
     const raw = VX_MAILAGENT_KEY || '';
     const isHex64 = /^[0-9a-fA-F]{64}$/.test(raw);

--- a/src/backend/services/settings.ts
+++ b/src/backend/services/settings.ts
@@ -4,18 +4,17 @@ import { SETTINGS_FILE } from '../utils/paths';
 
 import type { ApiConfig } from '../../shared/types';
 
+/** Application settings loaded from disk. */
 export interface Settings {
   virtualRoot: string;
   apiConfigs: ApiConfig[];
   signatures: Record<string, string>;
   fetcherAutoStart: boolean;
   sessionTimeoutMinutes: number;
-  // allow unknowns for forward-compat without typing explosion
   [key: string]: any;
 }
 
- 
-
+/** Load settings from the encrypted JSON file. */
 export function loadSettings(): Settings {
   let settings: Settings;
   try {
@@ -24,7 +23,6 @@ export function loadSettings(): Settings {
     } else {
       settings = defaultSettings();
     }
-    // Ensure required fields exist for forward-compat
     if (!Array.isArray(settings.apiConfigs)) settings.apiConfigs = [] as ApiConfig[];
     if (!settings.signatures || typeof settings.signatures !== 'object') settings.signatures = {};
     if (typeof settings.fetcherAutoStart !== 'boolean') settings.fetcherAutoStart = true;
@@ -38,6 +36,7 @@ export function loadSettings(): Settings {
   return settings;
 }
 
+/** Default settings when none exist on disk. */
 function defaultSettings(): Settings {
   return {
     virtualRoot: '',

--- a/src/backend/services/users.ts
+++ b/src/backend/services/users.ts
@@ -3,15 +3,18 @@ import { User } from '../../shared/types';
 
 let usersRepo: Repository<User> | null = null;
 
+/** Inject the repository used for user persistence. */
 export function setUsersRepo(repo: Repository<User>) {
   usersRepo = repo;
 }
 
+/** Retrieve the configured users repository. */
 export function getUsersRepo(): Repository<User> {
   if (!usersRepo) throw new Error('Users repository not initialized');
   return usersRepo;
 }
 
+/** Insert or update a user record. */
 export function upsertUser(next: User): User {
   const repo = getUsersRepo();
   const all = repo.getAll();
@@ -26,11 +29,13 @@ export function upsertUser(next: User): User {
   return next;
 }
 
+/** Find a user by identifier. */
 export function findUserById(id: string): User | undefined {
   const repo = getUsersRepo();
   return repo.getAll().find(u => u.id === id);
 }
 
+/** Find a user by email address (case-insensitive). */
 export function findUserByEmail(email: string): User | undefined {
   const repo = getUsersRepo();
   return repo.getAll().find(u => u.email.toLowerCase() === email.toLowerCase());

--- a/src/frontend/src/SettingsContext.tsx
+++ b/src/frontend/src/SettingsContext.tsx
@@ -13,11 +13,13 @@ interface SettingsContextValue {
   setLanguage: (lang: LanguageCode) => void;
 }
 
+/** Internal context for application settings. */
 const SettingsContext = createContext<SettingsContextValue | undefined>(undefined);
 
 const THEME_KEY = 'vx_theme_pref';
 const LANG_KEY = 'vx_lang';
 
+/** Provides theme and language preferences to descendants. */
 export const SettingsProvider: React.FC<{ children: React.ReactNode }>
   = ({ children }) => {
   const prefersDark = useMediaQuery('(prefers-color-scheme: dark)');
@@ -47,7 +49,6 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }>
     try { localStorage.setItem(LANG_KEY, lang); } catch {}
   };
 
-  // Sync Tailwind dark class on <html>
   useEffect(() => {
     const root = document.documentElement;
     if (effectiveMode === 'dark') root.classList.add('dark');
@@ -69,6 +70,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }>
   );
 };
 
+/** Access the current settings context. */
 export const useSettings = () => {
   const ctx = useContext(SettingsContext);
   if (!ctx) throw new Error('useSettings must be used within SettingsProvider');

--- a/src/frontend/src/authClient.ts
+++ b/src/frontend/src/authClient.ts
@@ -1,3 +1,4 @@
+/** Basic user profile information. */
 type User = {
   id: string;
   email: string;
@@ -7,6 +8,7 @@ type User = {
   lastLoginAt?: string;
 };
 
+/** Retrieve the current authenticated user, if any. */
 export async function whoAmI(): Promise<User | null> {
   try {
     const res = await fetch('/api/auth/whoami', { credentials: 'include' });
@@ -19,6 +21,7 @@ export async function whoAmI(): Promise<User | null> {
   }
 }
 
+/** Begin the Google OAuth login flow. */
 export async function startGoogleLogin(): Promise<void> {
   const res = await fetch('/api/auth/google/initiate');
   if (!res.ok) throw new Error('Failed to initiate login');
@@ -27,6 +30,7 @@ export async function startGoogleLogin(): Promise<void> {
   window.location.href = url;
 }
 
+/** Terminate the current session. */
 export async function logout(): Promise<void> {
   await fetch('/api/auth/logout', { method: 'POST', credentials: 'include' });
 }


### PR DESCRIPTION
## Summary
- document server setup and trim redundant comments
- add concise JSDoc to auth, fetcher, cleanup, and diagnostics routes
- document user, settings, and fetcher services plus frontend auth client

## Testing
- `cd src/backend && npm test` (fails: Missing script)
- `cd src/backend && npm run build`
- `cd src/frontend && npm test` (fails: Missing script)
- `cd src/frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adb2e4ac708329a8499185ce996287