### PR TITLE
refactor server route registration

### DIFF
--- a/src/backend/liveRepos.ts
+++ b/src/backend/liveRepos.ts
@@ -1,0 +1,49 @@
+import { Filter, Director, Agent, Prompt, Imprint, OrchestrationDiagnosticEntry, ConversationThread } from '../shared/types';
+import { requireReq, requireUserRepo, repoGetAll, repoSetAll } from './utils/repo-access';
+import { UserRequest } from './middleware/user-context';
+
+export interface LiveRepos {
+  getPrompts(req?: UserRequest): Prompt[];
+  setPrompts(req: UserRequest, next: Prompt[]): void;
+  getAgents(req?: UserRequest): Agent[];
+  setAgents(req: UserRequest, next: Agent[]): void;
+  getDirectors(req?: UserRequest): Director[];
+  setDirectors(req: UserRequest, next: Director[]): void;
+  getFilters(req?: UserRequest): Filter[];
+  setFilters(req: UserRequest, next: Filter[]): void;
+  getImprints(req?: UserRequest): Imprint[];
+  setImprints(req: UserRequest, next: Imprint[]): void;
+  getOrchestrationLog(req?: UserRequest): OrchestrationDiagnosticEntry[];
+  getConversations(req?: UserRequest): ConversationThread[];
+  setConversations(req: UserRequest, next: ConversationThread[]): void;
+  getSettings(req?: UserRequest): any;
+  getProviderRepo(req?: UserRequest): any;
+  getTracesRepo(req?: UserRequest): any;
+}
+
+export function createLiveRepos(): LiveRepos {
+  const get = <T>(name: string) => (req?: UserRequest) => repoGetAll<T>(requireReq(req), name);
+  const set = <T>(name: string) => (req: UserRequest, next: T[]) => repoSetAll<T>(requireReq(req), name, next);
+
+  return {
+    getPrompts: get<Prompt>('prompts'),
+    setPrompts: set<Prompt>('prompts'),
+    getAgents: get<Agent>('agents'),
+    setAgents: set<Agent>('agents'),
+    getDirectors: get<Director>('directors'),
+    setDirectors: set<Director>('directors'),
+    getFilters: get<Filter>('filters'),
+    setFilters: set<Filter>('filters'),
+    getImprints: get<Imprint>('imprints'),
+    setImprints: set<Imprint>('imprints'),
+    getOrchestrationLog: get<OrchestrationDiagnosticEntry>('orchestrationLog'),
+    getConversations: get<ConversationThread>('conversations'),
+    setConversations: set<ConversationThread>('conversations'),
+    getSettings: (req?: UserRequest) => {
+      const r = requireReq(req);
+      return repoGetAll<any>(r, 'settings')[0] || {};
+    },
+    getProviderRepo: (req?: UserRequest) => requireUserRepo(requireReq(req), 'providerEvents'),
+    getTracesRepo: (req?: UserRequest) => requireUserRepo(requireReq(req), 'traces'),
+  };
+}

--- a/src/backend/routes/index.ts
+++ b/src/backend/routes/index.ts
@@ -1,0 +1,108 @@
+import express from 'express';
+import { UserRequest } from '../middleware/user-context';
+import registerAuthSessionRoutes from './auth-session';
+import registerTestRoutes from './test';
+import registerMemoryRoutes from './memory';
+import registerOrchestrationRoutes from './orchestration';
+import registerSettingsRoutes from './settings';
+import registerAgentsRoutes from './agents';
+import registerFiltersRoutes from './filters';
+import registerDirectorsRoutes from './directors';
+import registerPromptsRoutes from './prompts';
+import registerTemplatesRoutes from './templates';
+import registerConversationsRoutes from './conversations';
+import registerWorkspacesRoutes from './workspaces';
+import registerImprintsRoutes from './imprints';
+import registerAccountsRoutes from './accounts';
+import registerFetcherRoutes from './fetcher';
+import registerDiagnosticsRoutes from './diagnostics';
+import registerDiagnosticTracesRoutes from './diagnostic-traces';
+import registerUnifiedDiagnosticsRoutes from './unified-diagnostics';
+import registerCleanupRoutes from './cleanup';
+import { FetcherManager } from '../services/fetcher-manager';
+import { ProviderEvent } from '../../shared/types';
+import { setOrchestrationLog as svcSetOrchestrationLog, logProviderEvent as svcLogProviderEvent, getOrchestrationLog, getTraces } from '../services/logging';
+import { newId } from '../utils/id';
+import { LiveRepos } from '../liveRepos';
+
+export interface RouteDeps extends LiveRepos {
+  fetcherManager: FetcherManager;
+}
+
+export default function registerRoutes(app: express.Express, deps: RouteDeps) {
+  registerAuthSessionRoutes(app);
+  registerTestRoutes(app, {
+    getPrompts: deps.getPrompts,
+    getDirectors: deps.getDirectors,
+    getAgents: deps.getAgents,
+  });
+  registerMemoryRoutes(app, {});
+  registerOrchestrationRoutes(app, {
+    getOrchestrationLog: deps.getOrchestrationLog,
+    setOrchestrationLog: (next, req?: UserRequest) => { svcSetOrchestrationLog(next, req); },
+    getSettings: deps.getSettings,
+  });
+  registerSettingsRoutes(app, {});
+  registerAgentsRoutes(app, {
+    getAgents: deps.getAgents,
+    setAgents: deps.setAgents,
+  });
+  registerFiltersRoutes(app, {
+    getFilters: deps.getFilters,
+    setFilters: deps.setFilters,
+  });
+  registerDirectorsRoutes(app, {
+    getDirectors: deps.getDirectors,
+    setDirectors: deps.setDirectors,
+  });
+  registerPromptsRoutes(app, {
+    getPrompts: deps.getPrompts,
+    setPrompts: deps.setPrompts,
+    getSettings: deps.getSettings,
+    getAgents: deps.getAgents,
+    getDirectors: deps.getDirectors,
+  });
+  registerTemplatesRoutes(app);
+  registerConversationsRoutes(app, {
+    getConversations: deps.getConversations,
+    setConversations: deps.setConversations,
+    getSettings: deps.getSettings,
+    logProviderEvent: (e: ProviderEvent, req?: UserRequest) => { svcLogProviderEvent(e, req); },
+    newId,
+    getDirectors: deps.getDirectors,
+    getAgents: deps.getAgents,
+  });
+  registerWorkspacesRoutes(app, {
+    getConversations: deps.getConversations,
+    setConversations: deps.setConversations,
+  });
+  registerImprintsRoutes(app, {
+    getImprints: deps.getImprints,
+    setImprints: deps.setImprints,
+  });
+  registerAccountsRoutes(app);
+  registerDiagnosticsRoutes(app, {
+    getOrchestrationLog: deps.getOrchestrationLog,
+    getConversations: deps.getConversations,
+  });
+  registerDiagnosticTracesRoutes(app, {
+    getTraces: (req?: UserRequest) => deps.getTracesRepo(req).getAll(),
+    setTraces: (req: UserRequest, next) => deps.getTracesRepo(req).setAll(next),
+  });
+  registerUnifiedDiagnosticsRoutes(app, {
+    getOrchestrationLog: (req?: UserRequest) => getOrchestrationLog(req),
+    getConversations: deps.getConversations,
+    getProviderEvents: (req?: UserRequest) => deps.getProviderRepo(req).getAll(),
+    getTraces: (req?: UserRequest) => getTraces(req),
+  });
+  registerFetcherRoutes(app, {
+    getStatus: (req: UserRequest) => deps.fetcherManager.getStatus(req),
+    startFetcherLoop: (req: UserRequest) => deps.fetcherManager.startFetcherLoop(req),
+    stopFetcherLoop: (req: UserRequest) => deps.fetcherManager.stopFetcherLoop(req),
+    fetchEmails: (req: UserRequest) => deps.fetcherManager.fetchEmails(req),
+    getSettings: (req: UserRequest) => deps.getSettings(req),
+    getFetcherLog: (req: UserRequest) => deps.fetcherManager.getFetcherLog(req),
+    setFetcherLog: (req: UserRequest, next) => deps.fetcherManager.setFetcherLog(req, next),
+  });
+  registerCleanupRoutes(app);
+}


### PR DESCRIPTION
## Summary
- extract repository access helpers for per-entity data
- centralize all route registration in a dedicated module
- streamline createServer to use modular route setup

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b56646935483299ba49875f2248177