### PR TITLE
refactor persistence to async

### DIFF
--- a/src/backend/middleware/user-context.ts
+++ b/src/backend/middleware/user-context.ts
@@ -30,7 +30,7 @@ export class UserContextError extends Error {
  * Middleware to attach user context to requests.
  * Requires authentication middleware to run first.
  */
-export function attachUserContext(req: UserRequest, res: Response, next: NextFunction): Response | void {
+export async function attachUserContext(req: UserRequest, res: Response, next: NextFunction): Promise<Response | void> {
   try {
     // Allow public endpoints (auth/health) to proceed without user context
     const path = (req as any).path || req.url || '';
@@ -64,7 +64,7 @@ export function attachUserContext(req: UserRequest, res: Response, next: NextFun
     }
     
     // Get or create repository bundle for user
-    const repos = getUserRepoBundle(uid);
+    const repos = await getUserRepoBundle(uid);
     
     // Attach user context to request
     (req as UserRequest).userContext = {

--- a/src/backend/repository/core.ts
+++ b/src/backend/repository/core.ts
@@ -3,7 +3,7 @@
  */
 export interface Repository<T> {
   /** Retrieve all records from storage. */
-  getAll(): T[];
+  getAll(): Promise<T[]>;
   /** Replace the entire collection in storage. */
-  setAll(next: T[]): void;
+  setAll(next: T[]): Promise<void>;
 }

--- a/src/backend/repository/fileRepositories.ts
+++ b/src/backend/repository/fileRepositories.ts
@@ -50,10 +50,10 @@ export class FileJsonRepository<T> extends FileRepoBase implements Repository<T>
     super(filePath, containerPath, uid);
   }
   
-  getAll(): T[] {
+  async getAll(): Promise<T[]> {
     try {
       if (fs.existsSync(this.filePath)) {
-        const data = persistence.loadAndDecrypt(this.filePath, this.containerPath) as T[];
+        const data = await persistence.loadAndDecrypt(this.filePath, this.containerPath) as T[];
         const fileStats = fs.statSync(this.filePath);
         this.logFileOperation('read', true, undefined, fileStats.size);
         return data;
@@ -74,7 +74,7 @@ export class FileJsonRepository<T> extends FileRepoBase implements Repository<T>
     }
   }
   
-  setAll(next: T[]): void {
+  async setAll(next: T[]): Promise<void> {
     let items = next;
     
     // Apply size limits if configured
@@ -83,12 +83,12 @@ export class FileJsonRepository<T> extends FileRepoBase implements Repository<T>
     }
     
     try {
-      persistence.encryptAndPersist(items, this.filePath, this.containerPath);
-      
+      await persistence.encryptAndPersist(items, this.filePath, this.containerPath);
+
       // Log successful write operation
       const fileStats = fs.existsSync(this.filePath) ? fs.statSync(this.filePath) : null;
       this.logFileOperation('write', true, undefined, fileStats?.size);
-      
+
     } catch (e) {
       const error = e as Error;
       this.logFileOperation('write', false, error.message);
@@ -110,7 +110,7 @@ export class FileJsonRepository<T> extends FileRepoBase implements Repository<T>
 
 /** Repository interface for fetcher logs. */
 export interface FetcherLogRepository extends Repository<FetcherLogEntry> {
-  append(e: FetcherLogEntry): void;
+  append(e: FetcherLogEntry): Promise<void>;
 }
 
 /** Fetcher log repository with TTL + cap pruning. */
@@ -144,10 +144,10 @@ export class FileFetcherLogRepository extends FileRepoBase implements FetcherLog
     }
   }
 
-  getAll(): FetcherLogEntry[] {
+  async getAll(): Promise<FetcherLogEntry[]> {
     try {
       if (fs.existsSync(this.filePath)) {
-        const data = this.prune(persistence.loadAndDecrypt(this.filePath, this.containerPath) as FetcherLogEntry[]);
+        const data = this.prune(await persistence.loadAndDecrypt(this.filePath, this.containerPath) as FetcherLogEntry[]);
         const fileStats = fs.statSync(this.filePath);
         this.logFileOperation('read', true, undefined, fileStats.size);
         return data;
@@ -162,10 +162,10 @@ export class FileFetcherLogRepository extends FileRepoBase implements FetcherLog
     }
   }
 
-  setAll(next: FetcherLogEntry[]): void {
+  async setAll(next: FetcherLogEntry[]): Promise<void> {
     const pruned = this.prune(next);
     try {
-      persistence.encryptAndPersist(pruned, this.filePath, this.containerPath);
+      await persistence.encryptAndPersist(pruned, this.filePath, this.containerPath);
       const fileStats = fs.existsSync(this.filePath) ? fs.statSync(this.filePath) : null;
       this.logFileOperation('write', true, undefined, fileStats?.size);
     } catch (e) {
@@ -176,16 +176,16 @@ export class FileFetcherLogRepository extends FileRepoBase implements FetcherLog
     }
   }
 
-  append(e: FetcherLogEntry): void {
-    const list = this.getAll();
+  async append(e: FetcherLogEntry): Promise<void> {
+    const list = await this.getAll();
     list.push(e);
-    this.setAll(list);
+    await this.setAll(list);
   }
 }
 
 /** Repository interface for orchestration diagnostics log. */
 export interface OrchestrationLogRepository extends Repository<OrchestrationDiagnosticEntry> {
-  append(e: OrchestrationDiagnosticEntry): void;
+  append(e: OrchestrationDiagnosticEntry): Promise<void>;
 }
 
 /** Orchestration diagnostics repository with TTL + cap pruning. */
@@ -219,10 +219,10 @@ export class FileOrchestrationLogRepository extends FileRepoBase implements Orch
     }
   }
 
-  getAll(): OrchestrationDiagnosticEntry[] {
+  async getAll(): Promise<OrchestrationDiagnosticEntry[]> {
     try {
       if (fs.existsSync(this.filePath)) {
-        const data = this.prune(persistence.loadAndDecrypt(this.filePath, this.containerPath) as OrchestrationDiagnosticEntry[]);
+        const data = this.prune(await persistence.loadAndDecrypt(this.filePath, this.containerPath) as OrchestrationDiagnosticEntry[]);
         const fileStats = fs.statSync(this.filePath);
         this.logFileOperation('read', true, undefined, fileStats.size);
         return data;
@@ -237,10 +237,10 @@ export class FileOrchestrationLogRepository extends FileRepoBase implements Orch
     }
   }
 
-  setAll(next: OrchestrationDiagnosticEntry[]): void {
+  async setAll(next: OrchestrationDiagnosticEntry[]): Promise<void> {
     const pruned = this.prune(next);
     try {
-      persistence.encryptAndPersist(pruned, this.filePath, this.containerPath);
+      await persistence.encryptAndPersist(pruned, this.filePath, this.containerPath);
       const fileStats = fs.existsSync(this.filePath) ? fs.statSync(this.filePath) : null;
       this.logFileOperation('write', true, undefined, fileStats?.size);
     } catch (e) {
@@ -251,16 +251,16 @@ export class FileOrchestrationLogRepository extends FileRepoBase implements Orch
     }
   }
 
-  append(e: OrchestrationDiagnosticEntry): void {
-    const list = this.getAll();
+  async append(e: OrchestrationDiagnosticEntry): Promise<void> {
+    const list = await this.getAll();
     list.push(e);
-    this.setAll(list);
+    await this.setAll(list);
   }
 }
 
 /** Repository interface for provider events. */
 export interface ProviderEventsRepository extends Repository<ProviderEvent> {
-  append(ev: ProviderEvent): void;
+  append(ev: ProviderEvent): Promise<void>;
 }
 
 /** Provider events repository persisted to disk with per-user support. */
@@ -298,10 +298,10 @@ export class FileProviderEventsRepository extends FileRepoBase implements Provid
     }
   }
   
-  getAll(): ProviderEvent[] {
+  async getAll(): Promise<ProviderEvent[]> {
     try {
       if (fs.existsSync(this.filePath)) {
-        const data = this.prune(persistence.loadAndDecrypt(this.filePath, this.containerPath) as ProviderEvent[]);
+        const data = this.prune(await persistence.loadAndDecrypt(this.filePath, this.containerPath) as ProviderEvent[]);
         const fileStats = fs.statSync(this.filePath);
         this.logFileOperation('read', true, undefined, fileStats.size);
         return data;
@@ -315,11 +315,11 @@ export class FileProviderEventsRepository extends FileRepoBase implements Provid
       return [];
     }
   }
-  
-  setAll(next: ProviderEvent[]): void {
+
+  async setAll(next: ProviderEvent[]): Promise<void> {
     const pruned = this.prune(next);
-    try { 
-      persistence.encryptAndPersist(pruned, this.filePath, this.containerPath);
+    try {
+      await persistence.encryptAndPersist(pruned, this.filePath, this.containerPath);
       const fileStats = fs.existsSync(this.filePath) ? fs.statSync(this.filePath) : null;
       this.logFileOperation('write', true, undefined, fileStats?.size);
     } catch (e) {
@@ -329,18 +329,18 @@ export class FileProviderEventsRepository extends FileRepoBase implements Provid
       throw error;
     }
   }
-  
-  append(ev: ProviderEvent): void {
-    const list = this.getAll();
+
+  async append(ev: ProviderEvent): Promise<void> {
+    const list = await this.getAll();
     list.push(ev);
-    this.setAll(list);
+    await this.setAll(list);
   }
 }
 
 /** Repository interface for traces. */
 export interface TracesRepository extends Repository<Trace> {
-  append(t: Trace): void;
-  update(id: string, updater: (t: Trace) => Trace | void): void;
+  append(t: Trace): Promise<void>;
+  update(id: string, updater: (t: Trace) => Trace | void): Promise<void>;
 }
 
 /** Trace repository persisted to disk with per-user support. */
@@ -378,10 +378,10 @@ export class FileTracesRepository extends FileRepoBase implements TracesReposito
     }
   }
   
-  getAll(): Trace[] {
+  async getAll(): Promise<Trace[]> {
     try {
       if (fs.existsSync(this.filePath)) {
-        const data = this.prune(persistence.loadAndDecrypt(this.filePath, this.containerPath) as Trace[]);
+        const data = this.prune(await persistence.loadAndDecrypt(this.filePath, this.containerPath) as Trace[]);
         const fileStats = fs.statSync(this.filePath);
         this.logFileOperation('read', true, undefined, fileStats.size);
         return data;
@@ -395,11 +395,11 @@ export class FileTracesRepository extends FileRepoBase implements TracesReposito
       return [];
     }
   }
-  
-  setAll(next: Trace[]): void {
+
+  async setAll(next: Trace[]): Promise<void> {
     const pruned = this.prune(next);
-    try { 
-      persistence.encryptAndPersist(pruned, this.filePath, this.containerPath);
+    try {
+      await persistence.encryptAndPersist(pruned, this.filePath, this.containerPath);
       const fileStats = fs.existsSync(this.filePath) ? fs.statSync(this.filePath) : null;
       this.logFileOperation('write', true, undefined, fileStats?.size);
     } catch (e) {
@@ -409,21 +409,21 @@ export class FileTracesRepository extends FileRepoBase implements TracesReposito
       throw error;
     }
   }
-  
-  append(t: Trace): void {
-    const list = this.getAll();
+
+  async append(t: Trace): Promise<void> {
+    const list = await this.getAll();
     list.push(t);
-    this.setAll(list);
+    await this.setAll(list);
   }
-  
-  update(id: string, updater: (t: Trace) => Trace | void): void {
-    const list = this.getAll();
+
+  async update(id: string, updater: (t: Trace) => Trace | void): Promise<void> {
+    const list = await this.getAll();
     const idx = list.findIndex(x => x.id === id);
     if (idx >= 0) {
       const cur = list[idx];
       const result = updater(cur);
       if (result) list[idx] = result;
-      this.setAll(list);
+      await this.setAll(list);
     }
   }
 }

--- a/src/backend/repository/registry.ts
+++ b/src/backend/repository/registry.ts
@@ -55,7 +55,7 @@ export class RepoBundleRegistry {
    * @param uid - User ID (must be pre-validated)
    * @returns Repository bundle for the user
    */
-  getBundle(uid: string): RepoBundle {
+  async getBundle(uid: string): Promise<RepoBundle> {
     let bundle = this.bundles.get(uid);
     
     if (bundle) {
@@ -87,7 +87,7 @@ export class RepoBundleRegistry {
     for (const f of filesToInit) {
       try {
         if (!fs.existsSync(f)) {
-          persistence.encryptAndPersist([], f, paths.root);
+          await persistence.encryptAndPersist([], f, paths.root);
         }
       } catch (e) {
         logger.warn('[REGISTRY] Failed to pre-create user file', { file: f, error: e });
@@ -229,6 +229,6 @@ export const repoBundleRegistry = new RepoBundleRegistry();
  * @param uid - User ID (must be pre-validated)
  * @returns Repository bundle
  */
-export function getUserRepoBundle(uid: string): RepoBundle {
+export function getUserRepoBundle(uid: string): Promise<RepoBundle> {
   return repoBundleRegistry.getBundle(uid);
 }

--- a/src/backend/services/users.ts
+++ b/src/backend/services/users.ts
@@ -15,9 +15,9 @@ export function getUsersRepo(): Repository<User> {
 }
 
 /** Insert or update a user record. */
-export function upsertUser(next: User): User {
+export async function upsertUser(next: User): Promise<User> {
   const repo = getUsersRepo();
-  const all = repo.getAll();
+  const all = await repo.getAll();
   const idx = all.findIndex(u => u.id === next.id);
   if (idx >= 0) {
     const cur = all[idx];
@@ -25,18 +25,20 @@ export function upsertUser(next: User): User {
   } else {
     all.push(next);
   }
-  repo.setAll(all);
+  await repo.setAll(all);
   return next;
 }
 
 /** Find a user by identifier. */
-export function findUserById(id: string): User | undefined {
+export async function findUserById(id: string): Promise<User | undefined> {
   const repo = getUsersRepo();
-  return repo.getAll().find(u => u.id === id);
+  const all = await repo.getAll();
+  return all.find(u => u.id === id);
 }
 
 /** Find a user by email address (case-insensitive). */
-export function findUserByEmail(email: string): User | undefined {
+export async function findUserByEmail(email: string): Promise<User | undefined> {
   const repo = getUsersRepo();
-  return repo.getAll().find(u => u.email.toLowerCase() === email.toLowerCase());
+  const all = await repo.getAll();
+  return all.find(u => u.email.toLowerCase() === email.toLowerCase());
 }

--- a/src/backend/utils/orchestration.ts
+++ b/src/backend/utils/orchestration.ts
@@ -55,16 +55,16 @@ export function getWorkspace(thread: ConversationThread): WorkspaceItem[] {
 /**
  * Replaces the workspace items for a conversation and persists the updated list.
  */
-export function setWorkspace(
+export async function setWorkspace(
   conversations: ConversationThread[],
   index: number,
   items: WorkspaceItem[],
   conversationsFilePath: string
-) {
+): Promise<void> {
   const current = conversations[index];
   conversations[index] = { ...current, workspaceItems: items } as ConversationThread;
   try {
-    persistence.encryptAndPersist(conversations, conversationsFilePath);
+    await persistence.encryptAndPersist(conversations, conversationsFilePath);
   } catch {}
 }
 
@@ -135,7 +135,7 @@ export async function runWorkspaceOp<TOut = any>(
     nowIso: () => string;
     resolve: () => { index: number; thread: ConversationThread };
     get: (thread: ConversationThread) => WorkspaceItem[];
-    set: (index: number, items: WorkspaceItem[]) => void;
+    set: (index: number, items: WorkspaceItem[]) => Promise<void>;
   }) => Promise<TOut>
 ): Promise<TOut> {
   const { conversations, dirThreadId, conversationsFilePath } = ctx;

--- a/src/backend/utils/repo-access.ts
+++ b/src/backend/utils/repo-access.ts
@@ -23,16 +23,16 @@ export function requireRepos(req: UserRequest): RepoBundle {
 }
 
 /** Get all items from a repository by key. */
-export function repoGetAll<T = any>(req: UserRequest, key: keyof RepoBundle): T[] {
-  const repo = requireUserRepo(req, key) as unknown as { getAll: () => T[] };
+export async function repoGetAll<T = any>(req: UserRequest, key: keyof RepoBundle): Promise<T[]> {
+  const repo = requireUserRepo(req, key) as unknown as { getAll: () => Promise<T[]> };
   if (!repo || typeof repo.getAll !== 'function') throw new Error('Repository does not support getAll');
   return repo.getAll();
 }
 
 /** Replace all items in a repository by key. */
-export function repoSetAll<T = any>(req: UserRequest, key: keyof RepoBundle, next: T[]): void {
-  const repo = requireUserRepo(req, key) as unknown as { setAll?: (n: T[]) => void };
+export async function repoSetAll<T = any>(req: UserRequest, key: keyof RepoBundle, next: T[]): Promise<void> {
+  const repo = requireUserRepo(req, key) as unknown as { setAll?: (n: T[]) => Promise<void> };
   if (!repo || typeof repo.setAll !== 'function') throw new Error('Repository does not support setAll');
-  repo.setAll!(next);
+  await repo.setAll!(next);
 }
 


### PR DESCRIPTION
## Summary
- centralize data directory resolution in utils/paths
- convert persistence operations to async fs.promises and await writes/reads
- update workspace helper to await persistence

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b67f33447c83299b26ec135b571b28