### PR TITLE
refactor: replace dynamic requires with static imports

### DIFF
--- a/src/backend/interfaces/index.ts
+++ b/src/backend/interfaces/index.ts
@@ -1,0 +1,5 @@
+import type { UserContext } from '../middleware/user-context';
+
+export interface ReqLike {
+  userContext?: UserContext;
+}

--- a/src/backend/providers/mail/outlook.ts
+++ b/src/backend/providers/mail/outlook.ts
@@ -2,16 +2,16 @@ import { graphRequest } from '../../utils/graph';
 import type { Account, EmailEnvelope } from '../../../shared/types';
 import type { IMailProvider, FetchOptions } from './base';
 import { OUTLOOK_CLIENT_ID, OUTLOOK_CLIENT_SECRET } from '../../config';
+import { ensureValidOutlookAccessToken } from '../../oauth-outlook';
 
 export const outlookProvider: IMailProvider = {
   id: 'outlook',
 
   async ensureValidAccessToken(account: Account) {
-    const { ensureValidOutlookAccessToken } = require('../../oauth-outlook');
     const result = await ensureValidOutlookAccessToken(
       account,
       OUTLOOK_CLIENT_ID!,
-      OUTLOOK_CLIENT_SECRET!
+      OUTLOOK_CLIENT_SECRET!,
     );
     return result;
   },

--- a/src/backend/routes/conversations.ts
+++ b/src/backend/routes/conversations.ts
@@ -1,10 +1,12 @@
 import express from 'express';
 import { ConversationThread, PromptMessage, ProviderEvent, Director, Agent } from '../../shared/types';
 import { conversationEngine } from '../services/engine';
+import { runAgentConversation } from '../services/orchestration';
 import { TOOL_DESCRIPTORS } from '../../shared/tools';
 import { createToolHandler } from '../toolCalls';
 import logger from '../services/logger';
-import { requireReq, requireRepos, ReqLike } from '../utils/repo-access';
+import { requireReq, requireRepos } from '../utils/repo-access';
+import type { ReqLike } from '../interfaces';
 
 export interface ConversationsRoutesDeps {
   getConversations: (req?: ReqLike) => Promise<ConversationThread[]>;
@@ -181,8 +183,6 @@ export default function registerConversationsRoutes(app: express.Express, deps: 
       } else {
         // Agent threads: use unified agent conversation logic
         try {
-          const { runAgentConversation } = require('../services/orchestration');
-          
           const agentResult = await runAgentConversation(
             t,
             userContent, // Use the user's message content

--- a/src/backend/services/fetcher.ts
+++ b/src/backend/services/fetcher.ts
@@ -3,10 +3,10 @@ import { newId } from '../utils/id';
 import { conversationEngine } from './engine';
 import { TOOL_DESCRIPTORS } from '../../shared/tools';
 import { FetcherLogEntry, Account, ConversationThread, OrchestrationDiagnosticEntry, ProviderEvent, Filter, Director, Agent, Prompt } from '../../shared/types';
-import { evaluateFilters, selectDirectorTriggers, shouldFinalizeDirector, ensureAgentThread } from './orchestration';
+import { evaluateFilters, selectDirectorTriggers, shouldFinalizeDirector, ensureAgentThread, runAgentConversation } from './orchestration';
 import { FETCHER_TTL_DAYS, USER_MAX_LOGS_PER_TYPE, PROVIDER_REQUEST_TIMEOUT_MS, CONVERSATION_STEP_TIMEOUT_MS } from '../config';
 import { beginTrace, endTrace, beginSpan, endSpan } from './logging';
-import { ReqLike } from '../utils/repo-access';
+import type { ReqLike } from '../interfaces';
 import logger from './logger';
 
 /** Dependencies required by the fetcher service. */
@@ -363,9 +363,8 @@ export function initFetcher(deps: FetcherDeps): FetcherService {
                     const tAg0 = Date.now();
                     
                     try {
-                      const { runAgentConversation } = require('./orchestration');
                       const agentInput = String(args.input || '');
-                      
+
                       const agentResult = await runAgentConversation(
                         agentThread,
                         agentInput,

--- a/src/backend/services/logging.ts
+++ b/src/backend/services/logging.ts
@@ -2,7 +2,8 @@ import { OrchestrationDiagnosticEntry, ProviderEvent, Trace, Span } from '../../
 import { TRACE_MAX_PAYLOAD, TRACE_MAX_SPANS, TRACE_PERSIST, TRACE_REDACT_FIELDS, TRACE_VERBOSE } from '../config';
 import { newId } from '../utils/id';
 import { OrchestrationLogRepository, ProviderEventsRepository, TracesRepository } from '../repository/fileRepositories';
-import { ReqLike, requireReq, requireUserRepo } from '../utils/repo-access';
+import { requireReq, requireUserRepo } from '../utils/repo-access';
+import type { ReqLike } from '../interfaces';
 
 // Resolve per-user repositories - user context required
 function getOrchRepo(req?: ReqLike): OrchestrationLogRepository {

--- a/src/backend/services/orchestration.ts
+++ b/src/backend/services/orchestration.ts
@@ -1,7 +1,9 @@
 import { Agent, Director, Filter, Prompt, ConversationThread } from '../../shared/types';
 import { beginSpan, endSpan } from './logging';
-import { ReqLike } from '../utils/repo-access';
 import { CONVERSATION_STEP_TIMEOUT_MS, TOOL_EXEC_TIMEOUT_MS } from '../config';
+import { conversationEngine } from './engine';
+import { newId } from '../utils/id';
+import type { ReqLike } from '../interfaces';
 
 export interface EmailContext {
   from: string;
@@ -171,7 +173,6 @@ export async function runAgentConversation(
     while (stepCount < LOOP_MAX) {
       stepCount++;
       
-      const { conversationEngine } = require('./engine');
 
       const t0 = Date.now();
       let stepTimeoutId: any;
@@ -196,7 +197,7 @@ export async function runAgentConversation(
         try {
           if (result.request) {
             logProviderEvent({
-              id: require('../utils/id').newId(),
+              id: newId(),
               conversationId: agentThread.id,
               provider: 'openai',
               type: 'request',
@@ -206,7 +207,7 @@ export async function runAgentConversation(
           }
           const usage = (result.response && (result.response as any).usage) || undefined;
           logProviderEvent({
-            id: require('../utils/id').newId(),
+            id: newId(),
             conversationId: agentThread.id,
             provider: 'openai',
             type: 'response',
@@ -315,7 +316,7 @@ export async function runAgentConversation(
       try {
         const now = new Date().toISOString();
         logProviderEvent({
-          id: require('../utils/id').newId(),
+          id: newId(),
           conversationId: agentThread.id,
           provider: 'openai',
           type: 'error',

--- a/src/backend/utils/graph.ts
+++ b/src/backend/utils/graph.ts
@@ -6,6 +6,7 @@
  * @param body Optional JSON payload string.
  */
 import { GRAPH_REQUEST_TIMEOUT_MS } from '../config';
+import https from 'https';
 
 export async function graphRequest<T = any>(
   pathWithQuery: string,
@@ -25,7 +26,6 @@ export async function graphRequest<T = any>(
   };
   const payload = typeof body === 'string' ? body : undefined;
   const json = await new Promise<any>((resolve, reject) => {
-    const https = require('https');
     const req = https.request(options as any, (res: any) => {
       const chunks: Buffer[] = [];
       res.on('data', (d: any) => chunks.push(Buffer.isBuffer(d) ? d : Buffer.from(d)));

--- a/src/backend/utils/repo-access.ts
+++ b/src/backend/utils/repo-access.ts
@@ -1,8 +1,8 @@
-import { UserContext } from '../middleware/user-context';
+import type { UserContext } from '../middleware/user-context';
+import type { ReqLike } from '../interfaces';
 import { RepoBundle } from '../repository/registry';
 
-/** Minimal request-like type carrying user context. */
-export type ReqLike = { userContext?: UserContext };
+export type { ReqLike } from '../interfaces';
 
 /** Ensure the request-like object has a valid user context. */
 export function requireReq<T extends ReqLike>(req?: T): T & { userContext: UserContext } {


### PR DESCRIPTION
## Summary
- convert backend modules to use static ES imports instead of `require`
- extract shared `ReqLike` interface into `src/backend/interfaces`
- import Outlook and Gmail providers statically for token refresh and mailbox fetch

## Testing
- `npm --prefix src/backend run build` *(fails: Cannot find module 'pino')*

------
https://chatgpt.com/codex/tasks/task_e_68b6d40327348329bfad81a36507a5b4