### PR TITLE
Use stable message IDs in editor

### DIFF
--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -246,6 +246,8 @@ export interface Agent {
 }
 
 export interface PromptMessage {
+  // Stable identifier for message ordering in editors
+  id?: string;
   role: 'system' | 'user' | 'assistant' | 'tool';
   // Assistant content may be null when tool_calls are present per OpenAI schema
   content: string | null;


### PR DESCRIPTION
## Summary
- add optional `id` to `PromptMessage`
- ensure `MessageListEditor` assigns and uses stable ids
- update content editing helpers to reference ids

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7e52b9948832990796d9f18738e06