### PR TITLE
Validate IDs in PUT CRUD routes

### DIFF
--- a/src/backend/routes/helpers.test.ts
+++ b/src/backend/routes/helpers.test.ts
@@ -1,0 +1,60 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import express from 'express';
+import { once } from 'node:events';
+import { AddressInfo } from 'node:net';
+import { createCrudRoutes, CrudRepoFunctions } from './helpers';
+
+interface Item { id: string; name: string; }
+
+async function startServer(repo: CrudRepoFunctions<Item>) {
+  const app = express();
+  app.use(express.json());
+  createCrudRoutes<Item>(app, '/api/items', repo, { itemName: 'item' });
+  const server = app.listen(0);
+  await once(server, 'listening');
+  const { port } = server.address() as AddressInfo;
+  return { server, url: `http://127.0.0.1:${port}` };
+}
+
+test('PUT returns 400 when body id mismatches path', async () => {
+  let items: Item[] = [{ id: '1', name: 'one' }];
+  const repo: CrudRepoFunctions<Item> = {
+    get: async () => items,
+    set: async (_req, next) => { items = next; }
+  };
+  const { server, url } = await startServer(repo);
+  try {
+    const res = await fetch(`${url}/api/items/1`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: '2', name: 'two' })
+    });
+    assert.strictEqual(res.status, 400);
+    const body = await res.json();
+    assert.ok(String(body.error).includes('ID'));
+    assert.deepStrictEqual(items, [{ id: '1', name: 'one' }]);
+  } finally {
+    server.close();
+  }
+});
+
+test('PUT assigns path id when body id missing', async () => {
+  let items: Item[] = [{ id: '1', name: 'one' }];
+  const repo: CrudRepoFunctions<Item> = {
+    get: async () => items,
+    set: async (_req, next) => { items = next; }
+  };
+  const { server, url } = await startServer(repo);
+  try {
+    const res = await fetch(`${url}/api/items/1`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'updated' })
+    });
+    assert.strictEqual(res.status, 200);
+    assert.deepStrictEqual(items, [{ id: '1', name: 'updated' }]);
+  } finally {
+    server.close();
+  }
+});

--- a/src/backend/routes/helpers.ts
+++ b/src/backend/routes/helpers.ts
@@ -118,11 +118,20 @@ export function createCrudRoutes<T extends Record<string, any>>(
       }
 
       let item: T = req.body;
-      
+
       if (beforeValidate) {
         item = beforeValidate(item, true);
       }
-      
+
+      // Ensure path ID matches or sets body ID before validation
+      const bodyId = item[idField];
+      if (bodyId == null) {
+        (item as any)[idField] = id;
+      } else if (bodyId !== id) {
+        logger.warn(`PUT ${basePath}/:id id mismatch`, { idParam: id, bodyId });
+        return res.status(400).json({ error: `${itemName} ID mismatch` });
+      }
+
       if (validate) {
         await validate(item, true);
       }


### PR DESCRIPTION
## Summary
- Ensure PUT /api/{resource}/:id rejects mismatched body IDs
- Test ID mismatch and assignment behavior

## Testing
- `npm test` (fails: Cannot find module 'pino')

------
https://chatgpt.com/codex/tasks/task_e_68b7e51b99148329b91c92a9607f17e2