### PR TITLE
Validate account IDs on update

### DIFF
--- a/src/backend/services/accounts.test.ts
+++ b/src/backend/services/accounts.test.ts
@@ -1,0 +1,34 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+
+import { updateAccount } from './accounts';
+import { ValidationError } from './error-handler';
+import type { Account } from '../../shared/types';
+import type { ReqLike } from '../utils/repo-access';
+
+test('updateAccount rejects mismatched ids', async () => {
+  const existing: Account = {
+    id: 'a1',
+    provider: 'gmail',
+    email: 'a1@example.com',
+    signature: '',
+    tokens: { accessToken: '', refreshToken: '', expiry: '' },
+  };
+
+  let persisted = false;
+  const repo = {
+    getAll: async () => [existing],
+    setAll: async () => { persisted = true; },
+  };
+
+  const req = { userContext: { uid: 'u1', repos: { accounts: repo } } } as unknown as ReqLike;
+  const next: Account = { ...existing, id: 'a2' };
+
+  await assert.rejects(
+    async () => updateAccount(req, 'a1', next),
+    (err: any) => err instanceof ValidationError && err.statusCode === 400,
+  );
+
+  assert.strictEqual(persisted, false);
+});
+


### PR DESCRIPTION
## Summary
- ensure account updates use the URL id; throw a 400 ValidationError when the payload id differs
- add unit test covering id mismatch rejection

## Testing
- `npm test` *(fails: Cannot find module 'pino')*


------
https://chatgpt.com/codex/tasks/task_e_68b7e53a47648329a03dce56937b7c40