### PR TITLE
fix: enforce workspace content inputs

### DIFF
--- a/src/backend/services/conversation-orchestrator.ts
+++ b/src/backend/services/conversation-orchestrator.ts
@@ -14,6 +14,7 @@ import { conversationEngine } from './engine';
 import { newId } from '../utils/id';
 import { repoAppendMessage, repoAppendMessages, repoFinalizeThreadStatus, repoGetThreadById } from './conversation-mutations';
 import { extractLastUserContent } from '../utils/message-transformers';
+import { ValidationError } from './error-handler';
 
 export interface ConversationContext {
   thread: ConversationThread;
@@ -509,7 +510,34 @@ export class ConversationOrchestrator {
     }
 
     // Persist workspace item via helper (validates schema and writes to repo)
-    const addedItem = await this.createWorkspaceItem(context, args, agentId, agentThread.id, userReq, { id: toolCall.id, name: toolCall.name });
+    let addedItem: WorkspaceItem | null;
+    try {
+      addedItem = await this.createWorkspaceItem(context, args, agentId, agentThread.id, userReq, { id: toolCall.id, name: toolCall.name });
+    } catch (error: any) {
+      if (error instanceof ValidationError) {
+        const toolErrorMsg = {
+          role: 'tool',
+          name: toolCall.name,
+          tool_call_id: toolCall.id,
+          content: JSON.stringify({ success: false, error: 'invalid_workspace_payload', detail: error.message })
+        };
+        await repoAppendMessages(userReq.repos, userReq.reqLike, context.thread.id, [toolErrorMsg as any]);
+        try {
+          await this.stepLogger.logStepError(
+            context.thread.id,
+            'director_tool',
+            0,
+            'workspace_add_item_invalid_payload',
+            context.thread.email.id,
+            context.thread.directorId
+          );
+        } catch (e) {
+          logger.debug('stepLogger.logStepError failed (workspace_add_item_invalid_payload)', { err: String(e) });
+        }
+        return true;
+      }
+      throw error;
+    }
     if (!addedItem) {
       const toolErrorMsg = {
         role: 'tool',
@@ -599,12 +627,25 @@ export class ConversationOrchestrator {
     toolCall?: { id: string; name: string }
   ): Promise<WorkspaceItem | null> {
     const handleTool = createToolHandler(requireRepos(requireReq(userReq.reqLike)) as any);
+    const mimeType = typeof args.mimeType === 'string' ? args.mimeType : undefined;
+    if (!mimeType) {
+      throw new ValidationError('workspace_add_item: mimeType is required');
+    }
+    const encoding = typeof args.encoding === 'string' ? args.encoding : undefined;
+    if (!encoding) {
+      throw new ValidationError('workspace_add_item: encoding is required');
+    }
+    const data = typeof args.data === 'string' ? args.data : undefined;
+    if (typeof data === 'undefined') {
+      throw new ValidationError('workspace_add_item: data is required');
+    }
+
     const payload: any = {
       label: typeof args.label === 'string' ? args.label : (typeof args.title === 'string' ? args.title : 'Untitled'),
       description: typeof args.description === 'string' ? args.description : undefined,
-      mimeType: typeof args.mimeType === 'string' ? args.mimeType : (typeof args.content === 'string' && !args.mimeType ? 'text/plain' : args.mimeType),
-      encoding: typeof args.encoding === 'string' ? args.encoding : 'utf8',
-      data: typeof args.data === 'string' ? args.data : (typeof args.content === 'string' ? args.content : undefined),
+      mimeType,
+      encoding,
+      data,
       // Do not coerce non-array tags; pass through for schema validation to reject
       ...(typeof args.tags !== 'undefined' ? { tags: Array.isArray(args.tags) ? args.tags : (args as any).tags } : {}),
       provenance: {

--- a/src/backend/services/workspace-service.ts
+++ b/src/backend/services/workspace-service.ts
@@ -1,4 +1,4 @@
-import { WorkspaceItem, ConversationThread } from '../../shared/types';
+import { WorkspaceItem, ConversationThread, WorkspaceContent } from '../../shared/types';
 import { ValidationError, NotFoundError } from './error-handler';
 import { newId } from '../utils/id';
 import { WorkspaceItemInput } from '../../shared/types';
@@ -36,7 +36,7 @@ export class WorkspaceService {
   }
 
   async addItem(input: WorkspaceItemInput): Promise<WorkspaceItem> {
-    this.validateEncoding(input.content.encoding);
+    this.validateContent(input.content);
     // Enforce array semantics for tags when provided
     const tagsAny = (input as any)?.metadata?.tags;
     if (typeof tagsAny !== 'undefined' && !Array.isArray(tagsAny)) {
@@ -67,9 +67,6 @@ export class WorkspaceService {
   }
 
   async updateItem(id: string, patch: Partial<WorkspaceItem>, expectedRevision?: number): Promise<WorkspaceItem> {
-    if (patch.content && typeof patch.content.encoding !== 'undefined') {
-      this.validateEncoding(patch.content.encoding);
-    }
     // Enforce array semantics if tags provided in patch
     const pTags = (patch as any)?.metadata?.tags;
     if (typeof pTags !== 'undefined' && !Array.isArray(pTags)) {
@@ -81,6 +78,11 @@ export class WorkspaceService {
     if (idx === -1) throw new NotFoundError('Item not found');
 
     const current = items[idx];
+    if (patch.content) {
+      const nextContent: WorkspaceContent = { ...current.content, ...patch.content };
+      this.validateContent(nextContent);
+      patch = { ...patch, content: nextContent };
+    }
     const currentRevision = current.lifecycle.revision ?? 0;
     if (typeof expectedRevision === 'number' && currentRevision !== expectedRevision) {
       throw new ValidationError(`Revision mismatch: expected ${expectedRevision}, got ${currentRevision}`);
@@ -145,10 +147,25 @@ export class WorkspaceService {
   }
 
   private validateEncoding(enc: any): void {
-    if (typeof enc === 'undefined') return;
     const allowed = ['utf8', 'base64', 'binary'];
     if (!allowed.includes(enc)) {
       throw new ValidationError(`Invalid encoding: ${enc}`);
+    }
+  }
+
+  private validateContent(content: WorkspaceContent): void {
+    if (!content || typeof content !== 'object') {
+      throw new ValidationError('content is required');
+    }
+    if (typeof content.mimeType !== 'string' || !content.mimeType) {
+      throw new ValidationError('content.mimeType is required');
+    }
+    if (typeof content.encoding !== 'string' || !content.encoding) {
+      throw new ValidationError('content.encoding is required');
+    }
+    this.validateEncoding(content.encoding);
+    if (typeof content.data !== 'string') {
+      throw new ValidationError('content.data must be a string');
     }
   }
 }

--- a/src/backend/toolCalls.ts
+++ b/src/backend/toolCalls.ts
@@ -11,6 +11,7 @@ import { Repository } from './repository/core';
 import { newId } from './utils/id';
 import type { RepoBundle } from './repository/registry';
 import { ensureAgentThread, runAgentConversation } from './services/orchestration-agent';
+import { ValidationError } from './services/error-handler';
 
 export function createToolHandler(repos: RepoBundle) {
   async function handleToolByName(name: string, params: any): Promise<ToolCallResult> {
@@ -353,11 +354,23 @@ async function handleWorkspaceToolCall(payload: any, workspaceRepo: Repository<W
       if (provErrors.length) {
         return { kind: 'workspace', success: false, result: { ok: false, errors: provErrors, received: sanitize(payload) }, error: 'Invalid workspace add payload' };
       }
+      const mimeType = typeof payload.mimeType === 'string' ? payload.mimeType : undefined;
+      if (!mimeType) {
+        throw new ValidationError('workspace_add_item: mimeType is required');
+      }
+      const encoding = typeof payload.encoding === 'string' ? payload.encoding : undefined;
+      if (!encoding) {
+        throw new ValidationError('workspace_add_item: encoding is required');
+      }
+      const data = typeof payload.data === 'string' ? payload.data : undefined;
+      if (typeof data === 'undefined') {
+        throw new ValidationError('workspace_add_item: data is required');
+      }
       const input = {
         content: {
-          mimeType: typeof payload.mimeType === 'string' ? payload.mimeType : 'text/plain',
-          encoding: typeof payload.encoding === 'string' ? payload.encoding : 'utf8',
-          data: typeof payload.data === 'string' ? payload.data : ''
+          mimeType,
+          encoding,
+          data
         },
         metadata: {
           ...(typeof payload.label === 'string' ? { label: payload.label } : {}),


### PR DESCRIPTION
## Summary
- require workspace tool payloads to send explicit mimeType, encoding, and data before invoking storage
- surface workspace payload validation failures back to the director thread instead of relying on defaults
- harden WorkspaceService validation so direct callers also reject missing content fields

## Testing
- npm --prefix src/backend run lint *(fails: missing @typescript-eslint/parser in sandbox)*
- npm --prefix src/backend run typecheck *(fails: missing openid-client/pino/cookie/jsonwebtoken packages in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d0aa12a92883298963d8484cc63ad0