### PR TITLE
feat: append director conversations atomically

### DIFF
--- a/src/backend/liveRepos.ts
+++ b/src/backend/liveRepos.ts
@@ -17,6 +17,7 @@ export interface LiveRepos {
   getOrchestrationLog(req?: ReqLike): Promise<OrchestrationEvent[]>;
   getConversations(req?: ReqLike): Promise<ConversationThread[]>;
   setConversations(req: ReqLike, next: ConversationThread[]): Promise<void>;
+  appendConversation(req: ReqLike, thread: ConversationThread): Promise<ConversationThread>;
   /** Append one or more messages to a thread atomically. */
   appendMessagesToConversation(req: ReqLike, threadId: string, messages: any[]): Promise<ConversationThread | null>;
   /** Finalize a thread's status atomically. */
@@ -40,6 +41,20 @@ export function createLiveRepos(): LiveRepos {
     return Array.isArray(arr) ? arr : [];
   };
   const set = <T>(name: keyof RepoBundle) => (req: ReqLike, next: T[]) => repoSetAll<T>(requireReq(req), name, next);
+  type ConversationRepoWithMutate = {
+    mutate: (
+      fn: (cur: ConversationThread[]) => Promise<ConversationThread[]> | ConversationThread[]
+    ) => Promise<ConversationThread[]>;
+  };
+  const requireConversationRepo = (req: ReqLike): ConversationRepoWithMutate => {
+    const r = requireReq(req);
+    const bundle = requireRepos(r);
+    const repo = bundle.conversations as unknown as ConversationRepoWithMutate | undefined;
+    if (!repo || typeof repo.mutate !== 'function') {
+      throw new Error('Conversations repository must support atomic mutate');
+    }
+    return repo;
+  };
 
   return {
     getPrompts: get<Prompt>('prompts'),
@@ -55,13 +70,23 @@ export function createLiveRepos(): LiveRepos {
     getOrchestrationLog: get<OrchestrationEvent>('orchestrationLog'),
     getConversations: get<ConversationThread>('conversations'),
     setConversations: set<ConversationThread>('conversations'),
-    appendMessagesToConversation: async (req: ReqLike, threadId: string, messages: any[]): Promise<ConversationThread | null> => {
-      const r = requireReq(req);
-      const bundle = requireRepos(r);
-      const repo = bundle.conversations as unknown as { mutate?: (fn: (cur: ConversationThread[]) => Promise<ConversationThread[]> | ConversationThread[]) => Promise<ConversationThread[]> };
-      if (!repo || typeof repo.mutate !== 'function') {
-        throw new Error('Conversations repository must support atomic mutate');
+    appendConversation: async (req: ReqLike, thread: ConversationThread): Promise<ConversationThread> => {
+      const repo = requireConversationRepo(req);
+      const next = await repo.mutate((cur) => {
+        const snapshot = Array.isArray(cur) ? cur : [];
+        if (snapshot.some((c) => c.id === thread.id)) {
+          throw new Error(`Conversation thread already exists: ${thread.id}`);
+        }
+        return [...snapshot, thread];
+      });
+      const appended = next.find((c) => c.id === thread.id);
+      if (!appended) {
+        throw new Error(`Failed to append conversation thread: ${thread.id}`);
       }
+      return appended;
+    },
+    appendMessagesToConversation: async (req: ReqLike, threadId: string, messages: any[]): Promise<ConversationThread | null> => {
+      const repo = requireConversationRepo(req);
       const next = await repo.mutate((cur) => {
         const idx = cur.findIndex((c) => c.id === threadId);
         if (idx === -1) return cur;
@@ -74,12 +99,7 @@ export function createLiveRepos(): LiveRepos {
       return next.find((c) => c.id === threadId) || null;
     },
     finalizeThreadStatusAtomic: async (req: ReqLike, threadId: string, status: 'completed' | 'failed'): Promise<ConversationThread | null> => {
-      const r = requireReq(req);
-      const bundle = requireRepos(r);
-      const repo = bundle.conversations as unknown as { mutate?: (fn: (cur: ConversationThread[]) => Promise<ConversationThread[]> | ConversationThread[]) => Promise<ConversationThread[]> };
-      if (!repo || typeof repo.mutate !== 'function') {
-        throw new Error('Conversations repository must support atomic mutate');
-      }
+      const repo = requireConversationRepo(req);
       const next = await repo.mutate((cur) => {
         const idx = cur.findIndex((c) => c.id === threadId);
         if (idx === -1) return cur;

--- a/src/backend/services/email-processor.ts
+++ b/src/backend/services/email-processor.ts
@@ -185,15 +185,15 @@ export class EmailProcessor {
 
     // Create and persist thread
     const thread = this.buildDirectorThread(director, envelope, context);
-    await this.persistDirectorThread(thread, traceId, userReq);
-    
+    const persistedThread = await this.persistDirectorThread(thread, traceId, userReq);
+
     // Log successful creation
-    this.logDirectorThreadCreated(director.id, thread.id, context.account);
+    this.logDirectorThreadCreated(director.id, persistedThread.id, context.account);
 
     // Start orchestration asynchronously
-    this.startDirectorOrchestration(thread, director, context, userReq);
+    this.startDirectorOrchestration(persistedThread, director, context, userReq);
 
-    return thread.id;
+    return persistedThread.id;
   }
 
   private validateDirectorConfig(director: Director, context: EmailProcessingContext): { isValid: boolean; error?: string } {
@@ -257,19 +257,19 @@ snippet: ${envelope.snippet}`;
     thread: ConversationThread,
     traceId: string,
     userReq: UserRequest
-  ): Promise<void> {
-    const conversations = await this.repos.getConversations(userReq);
-    const updatedConversations = [...conversations, thread];
-    await this.repos.setConversations(userReq, updatedConversations);
+  ): Promise<ConversationThread> {
+    const persistedThread = await this.repos.appendConversation(userReq, thread);
 
     const sConvCreate = beginSpan(traceId, {
       type: 'conversation_update',
       name: 'create_director_thread',
-      emailId: thread.email.id,
-      directorId: thread.directorId
+      emailId: persistedThread.email.id,
+      directorId: persistedThread.directorId
     }, userReq);
 
     endSpan(traceId, sConvCreate, { status: 'ok' }, userReq);
+
+    return persistedThread;
   }
 
   private logDirectorConfigError(directorId: string, account: any, error: string): void {


### PR DESCRIPTION
## Summary
- add an `appendConversation` helper on the conversations live repo that uses the repo mutate primitive for atomic inserts
- refactor the conversation mutation helpers in `createLiveRepos` to share a single `requireConversationRepo`
- persist new director threads via the append helper and pass the stored thread instance into orchestration

## Testing
- `npm --prefix src/backend run lint` *(blocked: @typescript-eslint/parser missing without full install)*
- `npm --prefix src/backend install --no-progress` *(blocked: repeated hangs/timeouts prevented dependency installation)*

------
https://chatgpt.com/codex/tasks/task_e_68d0a90977e48329b9fd7b6144575db0