### PR TITLE
refactor: use mutate for workspace items

### DIFF
--- a/src/backend/liveRepos.ts
+++ b/src/backend/liveRepos.ts
@@ -1,4 +1,4 @@
-import { Filter, Director, Agent, Prompt, Imprint, OrchestrationEvent, ConversationThread, EmailEnvelope, ProviderEvent } from '../shared/types';
+import { Filter, Director, Agent, Prompt, Imprint, OrchestrationEvent, ConversationThread, EmailEnvelope, ProviderEvent, WorkspaceItem } from '../shared/types';
 import { requireReq, requireUserRepo, repoGetAll, repoSetAll, requireRepos, ReqLike } from './utils/repo-access';
 import { RepoBundle } from './repository/registry';
 import { loadSettings } from './services/settings';
@@ -32,6 +32,11 @@ export interface LiveRepos {
   setAccounts(req: ReqLike, next: any[]): Promise<void>;
   getFetcherLog(req?: ReqLike): Promise<any[]>;
   setFetcherLog(req: ReqLike, next: any[]): Promise<void>;
+  getWorkspaceItems(req?: ReqLike): Promise<WorkspaceItem[]>;
+  mutateWorkspaceItems(
+    req: ReqLike,
+    updater: (current: WorkspaceItem[]) => Promise<WorkspaceItem[]> | WorkspaceItem[]
+  ): Promise<WorkspaceItem[]>;
 }
 
 export function createLiveRepos(): LiveRepos {
@@ -117,6 +122,28 @@ export function createLiveRepos(): LiveRepos {
     getConversationById: async (req: ReqLike, id: string) => {
       const conversations = await get<ConversationThread>('conversations')(req);
       return conversations.find((c: ConversationThread) => c.id === id) || null;
+    },
+    getWorkspaceItems: get<WorkspaceItem>('workspaceItems'),
+    mutateWorkspaceItems: async (
+      req: ReqLike,
+      updater: (current: WorkspaceItem[]) => Promise<WorkspaceItem[]> | WorkspaceItem[],
+    ): Promise<WorkspaceItem[]> => {
+      const r = requireReq(req);
+      const bundle = requireRepos(r);
+      const repo = bundle.workspaceItems as unknown as {
+        mutate?: (
+          fn: (cur: WorkspaceItem[]) => Promise<WorkspaceItem[]> | WorkspaceItem[]
+        ) => Promise<WorkspaceItem[]>;
+      };
+      if (!repo || typeof repo.mutate !== 'function') {
+        throw new Error('Workspace repository must support atomic mutate');
+      }
+      return await repo.mutate((cur) => {
+        if (!Array.isArray(cur)) {
+          throw new Error('Workspace repository returned non-array state');
+        }
+        return updater(cur);
+      });
     },
   };
 }

--- a/src/backend/routes/cleanup.ts
+++ b/src/backend/routes/cleanup.ts
@@ -1,8 +1,9 @@
 import express from 'express';
-import { requireReq, repoGetAll, repoSetAll, ReqLike } from '../utils/repo-access';
+import { requireReq, repoGetAll, repoSetAll, requireUserRepo, ReqLike } from '../utils/repo-access';
 import { LiveRepos } from '../liveRepos';
 import { errorHandler } from '../services/error-handler';
 import { WorkspaceService } from '../services/workspace-service';
+import { Repository } from '../repository/core';
 
 export default function registerCleanupRoutes(
   app: express.Express,
@@ -65,9 +66,13 @@ export default function registerCleanupRoutes(
       repoGetAll<any>(ureq, 'traces'),
       repoGetAll<any>(ureq, 'workspaceItems'),
     ]);
+    const workspaceRepo = requireUserRepo(ureq, 'workspaceItems') as unknown as Repository<any>;
+    if (!workspaceRepo || typeof workspaceRepo.getAll !== 'function' || typeof workspaceRepo.mutate !== 'function') {
+      throw new Error('Workspace repository must support getAll and mutate operations');
+    }
     const wsService = new WorkspaceService({
-      getItems: async () => await repoGetAll<any>(ureq, 'workspaceItems'),
-      setItems: async (next) => await repoSetAll<any>(ureq, 'workspaceItems', next),
+      getItems: async () => await workspaceRepo.getAll(),
+      mutateItems: async (updater) => await workspaceRepo.mutate!(updater),
     });
     
     // Clear fetcher log through manager
@@ -121,9 +126,13 @@ export default function registerCleanupRoutes(
   }));
   app.delete('/api/cleanup/workspace-items', errorHandler.wrapAsync(async (req: express.Request, res: express.Response) => {
     const ureq = requireReq(req as ReqLike);
+    const workspaceRepo = requireUserRepo(ureq, 'workspaceItems') as unknown as Repository<any>;
+    if (!workspaceRepo || typeof workspaceRepo.getAll !== 'function' || typeof workspaceRepo.mutate !== 'function') {
+      throw new Error('Workspace repository must support getAll and mutate operations');
+    }
     const service = new WorkspaceService({
-      getItems: async () => await repoGetAll<any>(ureq, 'workspaceItems'),
-      setItems: async (next) => await repoSetAll<any>(ureq, 'workspaceItems', next),
+      getItems: async () => await workspaceRepo.getAll(),
+      mutateItems: async (updater) => await workspaceRepo.mutate!(updater),
     });
     const deleted = await service.purgeAll();
     res.json({ success: true, deleted, message: `Deleted ${deleted} workspace items` });

--- a/src/backend/routes/workspaces.ts
+++ b/src/backend/routes/workspaces.ts
@@ -1,9 +1,10 @@
 import express from 'express';
 import { WorkspaceItem, ConversationThread } from '../../shared/types.js';
 import logger from '../services/logger';
-import { requireReq, repoGetAll, repoSetAll, ReqLike } from '../utils/repo-access';
+import { requireReq, requireUserRepo, ReqLike } from '../utils/repo-access';
 import { errorHandler, NotFoundError } from '../services/error-handler';
 import { WorkspaceService } from '../services/workspace-service';
+import { Repository } from '../repository/core';
 
 export interface WorkspacesRoutesDeps {
   getConversations: (req?: ReqLike) => Promise<ConversationThread[]>;
@@ -12,9 +13,15 @@ export interface WorkspacesRoutesDeps {
 
 function createWorkspaceService(req: ReqLike, deps?: WorkspacesRoutesDeps): WorkspaceService {
   const ureq = requireReq(req);
+  const workspaceRepo = requireUserRepo(ureq, 'workspaceItems') as unknown as Repository<WorkspaceItem>;
+  if (!workspaceRepo || typeof workspaceRepo.getAll !== 'function' || typeof workspaceRepo.mutate !== 'function') {
+    throw new Error('Workspace repository must support getAll and mutate operations');
+  }
   const base = {
-    getItems: async () => await repoGetAll<WorkspaceItem>(ureq, 'workspaceItems'),
-    setItems: async (next: WorkspaceItem[]) => await repoSetAll<WorkspaceItem>(ureq, 'workspaceItems', next),
+    getItems: async () => await workspaceRepo.getAll(),
+    mutateItems: async (updater: (current: WorkspaceItem[]) => Promise<WorkspaceItem[]> | WorkspaceItem[]) => {
+      return await workspaceRepo.mutate!(updater);
+    },
   } as const;
 
   if (!deps) {

--- a/src/backend/services/workspace-service.ts
+++ b/src/backend/services/workspace-service.ts
@@ -4,31 +4,36 @@ import { newId } from '../utils/id';
 import { WorkspaceItemInput } from '../../shared/types';
 
 export type GetItemsFn = () => Promise<WorkspaceItem[]>;
-export type SetItemsFn = (next: WorkspaceItem[]) => Promise<void>;
+export type MutateItemsFn = (
+  updater: (current: WorkspaceItem[]) => Promise<WorkspaceItem[]> | WorkspaceItem[]
+) => Promise<WorkspaceItem[]>;
 export type GetConversationsFn = () => Promise<ConversationThread[]>;
 export type SetConversationsFn = (next: ConversationThread[]) => Promise<void>;
 
 export interface WorkspaceServiceDeps {
   getItems: GetItemsFn;
-  setItems: SetItemsFn;
+  mutateItems: MutateItemsFn;
   getConversations?: GetConversationsFn;
   setConversations?: SetConversationsFn;
 }
 
 export class WorkspaceService {
   private readonly getItems: GetItemsFn;
-  private readonly setItems: SetItemsFn;
+  private readonly mutateItems: MutateItemsFn;
 
   constructor(deps: WorkspaceServiceDeps) {
     this.getItems = deps.getItems;
-    this.setItems = deps.setItems;
+    if (typeof deps.mutateItems !== 'function') {
+      throw new Error('WorkspaceService requires mutateItems dependency');
+    }
+    this.mutateItems = deps.mutateItems;
     // Conversation association is derivable; optional deps intentionally unused.
   }
 
   async listItems(includeDeleted: boolean = false): Promise<WorkspaceItem[]> {
     const items = await this.getItems();
     return includeDeleted ? items : items.filter(i => !i.lifecycle.deleted);
-    }
+  }
 
   async getItem(id: string): Promise<WorkspaceItem | null> {
     const items = await this.getItems();
@@ -61,8 +66,7 @@ export class WorkspaceService {
       },
     };
 
-    const items = await this.getItems();
-    await this.setItems([...items, item]);
+    await this.mutateItems((current) => [...current, item]);
     return item;
   }
 
@@ -76,59 +80,69 @@ export class WorkspaceService {
       throw new ValidationError('metadata.tags must be an array of strings');
     }
 
-    const items = await this.getItems();
-    const idx = items.findIndex(i => i.id === id);
-    if (idx === -1) throw new NotFoundError('Item not found');
+    let updated: WorkspaceItem | null = null;
+    await this.mutateItems((current) => {
+      const idx = current.findIndex(i => i.id === id);
+      if (idx === -1) {
+        throw new NotFoundError('Item not found');
+      }
+      const target = current[idx];
+      const currentRevision = target.lifecycle.revision ?? 0;
+      if (typeof expectedRevision === 'number' && currentRevision !== expectedRevision) {
+        throw new ValidationError(`Revision mismatch: expected ${expectedRevision}, got ${currentRevision}`);
+      }
 
-    const current = items[idx];
-    const currentRevision = current.lifecycle.revision ?? 0;
-    if (typeof expectedRevision === 'number' && currentRevision !== expectedRevision) {
-      throw new ValidationError(`Revision mismatch: expected ${expectedRevision}, got ${currentRevision}`);
+      const nextItem: WorkspaceItem = {
+        ...target,
+        ...patch,
+        lifecycle: {
+          ...target.lifecycle,
+          ...patch.lifecycle,
+          updated: new Date().toISOString(),
+          revision: currentRevision + 1,
+        },
+      };
+      updated = nextItem;
+      const next = current.slice();
+      next[idx] = nextItem;
+      return next;
+    });
+    if (!updated) {
+      throw new NotFoundError('Item not found');
     }
-
-    const updated: WorkspaceItem = {
-      ...current,
-      ...patch,
-      lifecycle: {
-        ...current.lifecycle,
-        ...patch.lifecycle,
-        updated: new Date().toISOString(),
-        revision: currentRevision + 1,
-      },
-    };
-
-    const next = items.slice();
-    next[idx] = updated;
-    await this.setItems(next);
     return updated;
   }
 
   async softDeleteItem(id: string): Promise<WorkspaceItem> {
-    const items = await this.getItems();
-    const idx = items.findIndex(i => i.id === id);
-    if (idx === -1) throw new NotFoundError('Item not found');
-
-    const current = items[idx];
-    const updated: WorkspaceItem = {
-      ...current,
-      lifecycle: {
-        ...current.lifecycle,
-        deleted: true,
-        updated: new Date().toISOString(),
-        revision: (current.lifecycle.revision ?? 0) + 1,
-      },
-    };
-
-    const next = items.slice();
-    next[idx] = updated;
-    await this.setItems(next);
-    return updated;
+    let deleted: WorkspaceItem | null = null;
+    await this.mutateItems((current) => {
+      const idx = current.findIndex(i => i.id === id);
+      if (idx === -1) {
+        throw new NotFoundError('Item not found');
+      }
+      const existing = current[idx];
+      const nextItem: WorkspaceItem = {
+        ...existing,
+        lifecycle: {
+          ...existing.lifecycle,
+          deleted: true,
+          updated: new Date().toISOString(),
+          revision: (existing.lifecycle.revision ?? 0) + 1,
+        },
+      };
+      deleted = nextItem;
+      const next = current.slice();
+      next[idx] = nextItem;
+      return next;
+    });
+    if (!deleted) {
+      throw new NotFoundError('Item not found');
+    }
+    return deleted;
   }
 
   async hardDeleteItem(id: string): Promise<void> {
-    const items = await this.getItems();
-    const next = items.filter(i => i.id !== id);
-    await this.setItems(next);
+    await this.mutateItems((current) => current.filter(i => i.id !== id));
   }
 
   // Note: Association is derivable by WorkspaceItem.provenance.conversationId.
@@ -138,9 +152,11 @@ export class WorkspaceService {
    * Purge all workspace items for the current user. Returns the number of deleted items.
    */
   async purgeAll(): Promise<number> {
-    const items = await this.getItems();
-    const count = Array.isArray(items) ? items.length : 0;
-    await this.setItems([]);
+    let count = 0;
+    await this.mutateItems((current) => {
+      count = Array.isArray(current) ? current.length : 0;
+      return [];
+    });
     return count;
   }
 

--- a/src/backend/tests/workspace-service.unit.cjs
+++ b/src/backend/tests/workspace-service.unit.cjs
@@ -7,7 +7,11 @@ test('workspace-service: add, update, soft/hard delete, revision guard', async (
   const items = [];
   const svc = new WorkspaceService({
     getItems: async () => items.slice(),
-    setItems: async (next) => { items.splice(0, items.length, ...next); },
+    mutateItems: async (updater) => {
+      const next = await Promise.resolve(updater(items.slice()));
+      items.splice(0, items.length, ...next);
+      return items.slice();
+    },
   });
   // Add
   const added = await svc.addItem({
@@ -35,7 +39,14 @@ test('workspace-service: add, update, soft/hard delete, revision guard', async (
 test('workspace-service: encoding validation', async () => {
   const { WorkspaceService } = require(path.join(__dirname, '..', 'dist', 'backend', 'services', 'workspace-service.js'));
   const items = [];
-  const svc = new WorkspaceService({ getItems: async () => items.slice(), setItems: async (n) => { items.splice(0, items.length, ...n); } });
+  const svc = new WorkspaceService({
+    getItems: async () => items.slice(),
+    mutateItems: async (updater) => {
+      const next = await Promise.resolve(updater(items.slice()));
+      items.splice(0, items.length, ...next);
+      return items.slice();
+    },
+  });
   await assert.rejects(() => svc.addItem({
     content: { mimeType: 'text/plain', encoding: 'bogus', data: 'x' },
     metadata: { tags: [] },

--- a/src/backend/toolCalls.ts
+++ b/src/backend/toolCalls.ts
@@ -343,9 +343,12 @@ function validScope(s: any): s is MemoryScope {
 async function handleWorkspaceToolCall(payload: any, workspaceRepo: Repository<WorkspaceItem>): Promise<ToolCallResult> {
   logger.info('[TOOLCALL] workspace', { payload });
   try {
+    if (typeof workspaceRepo.mutate !== 'function') {
+      throw new Error('Workspace repository must support mutate operations');
+    }
     const service = new WorkspaceService({
       getItems: () => workspaceRepo.getAll(),
-      setItems: (next) => workspaceRepo.setAll(next),
+      mutateItems: (updater) => workspaceRepo.mutate!(updater),
     });
     if (payload.action === 'add') {
       const prov = payload?.provenance || {};


### PR DESCRIPTION
## Summary
- refactor `WorkspaceService` to depend on repository mutate operations and perform add/update/delete inside a single mutation
- expose workspace item mutate access via live repos and update routes/tool handlers to pass the repository mutate API
- adjust workspace service tests to the new mutate-based contract

## Testing
- npm --prefix src/backend run lint *(fails: missing @typescript-eslint/parser in environment)*
- npm --prefix src/backend run typecheck *(fails: missing openid-client/pino/jsonwebtoken/cookie types in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0a918ebd483298fece953431cab30